### PR TITLE
Client Variation Functions and Exception Handling

### DIFF
--- a/src/cfclient.erl
+++ b/src/cfclient.erl
@@ -6,11 +6,7 @@
 -module(cfclient).
 
 %% API
--export([start/1, start/2]).
--export([bool_variation/3]).
--export([retrieve_flags/0]).
--export([retrieve_segments/0]).
--export([close/0]).
+-export([start/1, start/2, bool_variation/3, string_variation/3, retrieve_flags/0, retrieve_segments/0, close/0, number_variation/3, json_variation/3]).
 
 %% Constants
 
@@ -24,14 +20,10 @@ start(ApiKey) ->
 start(ApiKey, Options) ->
   cfclient_instance:start(ApiKey, Options).
 
--spec bool_variation(FlagKey :: binary(), Target :: cfclient_evaluator:target(), Default :: cfapi_evaluation:cfapi_evaluation()) -> cfapi_evaluation:cfapi_evaluation().
+-spec bool_variation(FlagKey :: binary(), Target :: cfclient_evaluator:target(), Default :: binary()) -> binary().
 bool_variation(FlagKey, Target, Default) ->
-%%  try cfclient_evaluator:bool_variation(FlagKey, Target, Default)
-%%  catch
-%%    error:ba -> binary_to_integer(Variation)
-%%  end.
   try
-    case cfclient_evaluator:bool_variation(FlagKey, Target, Default) of
+    case cfclient_evaluator:bool_variation(FlagKey, Target) of
       {ok, Variation} -> Variation;
       not_ok -> Default
     end
@@ -41,14 +33,36 @@ bool_variation(FlagKey, Target, Default) ->
       Default
   end.
 
--spec string_variation(FlagKey :: binary(), Target :: cfclient_evaluator:target(), Default :: cfapi_evaluation:cfapi_evaluation()) -> cfapi_evaluation:cfapi_evaluation().
+-spec string_variation(FlagKey :: binary(), Target :: cfclient_evaluator:target(), Default :: binary()) -> binary().
 string_variation(FlagKey, Target, Default) ->
-%%  try cfclient_evaluator:bool_variation(FlagKey, Target, Default)
-%%  catch
-%%    error:ba -> binary_to_integer(Variation)
-%%  end.
   try
-    case cfclient_evaluator:bool_variation(FlagKey, Target, Default) of
+    case cfclient_evaluator:string_variation(FlagKey, Target) of
+      {ok, Variation} -> Variation;
+      not_ok -> Default
+    end
+  catch
+    _:_:Stacktrace ->
+      logger:error("Error when doing bool variation for Flag: ~p~n \n Target: ~p~n \n Error: ~p~n" , [FlagKey, Target, Stacktrace]),
+      Default
+  end.
+
+-spec number_variation(FlagKey :: binary(), Target :: cfclient_evaluator:target(), Default :: number()) -> number().
+number_variation(FlagKey, Target, Default) ->
+  try
+    case cfclient_evaluator:number_variation(FlagKey, Target) of
+      {ok, Variation} -> Variation;
+      not_ok -> Default
+    end
+  catch
+    _:_:Stacktrace ->
+      logger:error("Error when doing bool variation for Flag: ~p~n \n Target: ~p~n \n Error: ~p~n" , [FlagKey, Target, Stacktrace]),
+      Default
+  end.
+
+-spec json_variation(FlagKey :: binary(), Target :: cfclient_evaluator:target(), Default :: map()) -> map().
+json_variation(FlagKey, Target, Default) ->
+  try
+    case cfclient_evaluator:string_variation(FlagKey, Target) of
       {ok, Variation} -> Variation;
       not_ok -> Default
     end

--- a/src/cfclient.erl
+++ b/src/cfclient.erl
@@ -41,6 +41,23 @@ bool_variation(FlagKey, Target, Default) ->
       Default
   end.
 
+-spec string_variation(FlagKey :: binary(), Target :: cfclient_evaluator:target(), Default :: cfapi_evaluation:cfapi_evaluation()) -> cfapi_evaluation:cfapi_evaluation().
+string_variation(FlagKey, Target, Default) ->
+%%  try cfclient_evaluator:bool_variation(FlagKey, Target, Default)
+%%  catch
+%%    error:ba -> binary_to_integer(Variation)
+%%  end.
+  try
+    case cfclient_evaluator:bool_variation(FlagKey, Target, Default) of
+      {ok, Variation} -> Variation;
+      not_ok -> Default
+    end
+  catch
+    _:_:Stacktrace ->
+      logger:error("Error when doing bool variation for Flag: ~p~n \n Target: ~p~n \n Error: ~p~n" , [FlagKey, Target, Stacktrace]),
+      Default
+  end.
+
 
 -spec retrieve_flags() -> ok.
 retrieve_flags() ->

--- a/src/cfclient.erl
+++ b/src/cfclient.erl
@@ -25,11 +25,13 @@ bool_variation(FlagKey, Target, Default) ->
   try
     case cfclient_evaluator:bool_variation(FlagKey, Target) of
       {ok, Variation} -> Variation;
-      not_ok -> Default
+      not_ok ->
+        logger:debug("Couldn't do evaluation for Flag: ~p~n \n Target ~p~n \n Returning user supplied Default" , [FlagKey, Target]),
+        Default
     end
   catch
     _:_:Stacktrace ->
-      logger:error("Error when doing bool variation for Flag: ~p~n \n Target: ~p~n \n Error: ~p~n" , [FlagKey, Target, Stacktrace]),
+      logger:error("Error when doing bool variation for Flag: ~p~n \n Target: ~p~n \n Error: ~p~n \n Returning user supplied Default" , [FlagKey, Target, Stacktrace]),
       Default
   end.
 
@@ -38,11 +40,13 @@ string_variation(FlagKey, Target, Default) ->
   try
     case cfclient_evaluator:string_variation(FlagKey, Target) of
       {ok, Variation} -> Variation;
-      not_ok -> Default
+      not_ok ->
+        logger:debug("Couldn't do evaluation for Flag: ~p~n \n Target ~p~n \n Returning user supplied Default" , [FlagKey, Target]),
+        Default
     end
   catch
     _:_:Stacktrace ->
-      logger:error("Error when doing bool variation for Flag: ~p~n \n Target: ~p~n \n Error: ~p~n" , [FlagKey, Target, Stacktrace]),
+      logger:error("Unknown Error when doing bool variation for Flag: ~p~n \n Target: ~p~n \n Error: ~p~n \n Returning user supplied Default" , [FlagKey, Target, Stacktrace]),
       Default
   end.
 
@@ -51,11 +55,13 @@ number_variation(FlagKey, Target, Default) ->
   try
     case cfclient_evaluator:number_variation(FlagKey, Target) of
       {ok, Variation} -> Variation;
-      not_ok -> Default
+      not_ok ->
+        logger:debug("Couldn't do evaluation for Flag: ~p~n \n Target ~p~n \n Returning user supplied Default" , [FlagKey, Target]),
+        Default
     end
   catch
     _:_:Stacktrace ->
-      logger:error("Error when doing bool variation for Flag: ~p~n \n Target: ~p~n \n Error: ~p~n" , [FlagKey, Target, Stacktrace]),
+      logger:error("Error when doing bool variation for Flag: ~p~n \n Target: ~p~n \n Error: ~p~n \n Returning user supplied Default" , [FlagKey, Target, Stacktrace]),
       Default
   end.
 
@@ -64,11 +70,13 @@ json_variation(FlagKey, Target, Default) ->
   try
     case cfclient_evaluator:string_variation(FlagKey, Target) of
       {ok, Variation} -> Variation;
-      not_ok -> Default
+      not_ok ->
+        logger:debug("Couldn't do evaluation for Flag: ~p~n \n Target ~p~n \n Returning user supplied Default" , [FlagKey, Target]),
+        Default
     end
   catch
     _:_:Stacktrace ->
-      logger:error("Error when doing bool variation for Flag: ~p~n \n Target: ~p~n \n Error: ~p~n" , [FlagKey, Target, Stacktrace]),
+      logger:error("Error when doing bool variation for Flag: ~p~n \n Target: ~p~n \n Error: ~p~n \n Returning user supplied Default" , [FlagKey, Target, Stacktrace]),
       Default
   end.
 

--- a/src/cfclient.erl
+++ b/src/cfclient.erl
@@ -30,7 +30,11 @@ bool_variation(FlagKey, Target, Default) ->
 %%  catch
 %%    error:ba -> binary_to_integer(Variation)
 %%  end.
-  try cfclient_evaluator:bool_variation(FlagKey, Target, Default)
+  try
+    case cfclient_evaluator:bool_variation(FlagKey, Target, Default) of
+      {ok, Variation} -> Variation;
+      not_ok -> Default
+    end
   catch
     _:_:Stacktrace ->
       logger:error("Error when doing bool variation for Flag: ~p~n \n Target: ~p~n \n Error: ~p~n" , [FlagKey, Target, Stacktrace]),

--- a/src/cfclient.erl
+++ b/src/cfclient.erl
@@ -68,7 +68,7 @@ number_variation(FlagKey, Target, Default) ->
 -spec json_variation(FlagKey :: binary(), Target :: cfclient_evaluator:target(), Default :: map()) -> map().
 json_variation(FlagKey, Target, Default) ->
   try
-    case cfclient_evaluator:string_variation(FlagKey, Target) of
+    case cfclient_evaluator:json_variation(FlagKey, Target) of
       {ok, Variation} -> Variation;
       not_ok ->
         logger:debug("Couldn't do evaluation for Flag: ~p~n \n Target ~p~n \n Returning user supplied Default" , [FlagKey, Target]),

--- a/src/cfclient.erl
+++ b/src/cfclient.erl
@@ -26,7 +26,17 @@ start(ApiKey, Options) ->
 
 -spec bool_variation(FlagKey :: binary(), Target :: cfclient_evaluator:target(), Default :: cfapi_evaluation:cfapi_evaluation()) -> cfapi_evaluation:cfapi_evaluation().
 bool_variation(FlagKey, Target, Default) ->
-  cfclient_evaluator:bool_variation(FlagKey, Target, Default).
+%%  try cfclient_evaluator:bool_variation(FlagKey, Target, Default)
+%%  catch
+%%    error:ba -> binary_to_integer(Variation)
+%%  end.
+  try cfclient_evaluator:bool_variation(FlagKey, Target, Default)
+  catch
+    _:_:Stacktrace ->
+      logger:error("Error when doing bool variation for Flag: ~p~n \n Target: ~p~n \n Error: ~p~n" , [FlagKey, Target, Stacktrace]),
+      Default
+  end.
+
 
 -spec retrieve_flags() -> ok.
 retrieve_flags() ->

--- a/src/cfclient_cache_repository.erl
+++ b/src/cfclient_cache_repository.erl
@@ -19,14 +19,7 @@ get_from_cache({Type, Identifier}, CachePID) ->
 
 -spec get(CachePID :: pid(), Identifier :: binary()) -> term().
 get(CachePID, FlagKey) ->
-  Flag = lru:get(CachePID, FlagKey),
-  if
-    Flag /= undefined ->
-      Flag;
-  %% @TODO returning undefined for now - but we need to figure out if this repository should return errors or not - or just let the caller handle it.
-    true ->
-      undefined
-  end.
+  lru:get(CachePID, FlagKey).
 
 %% @doc Places a flag or segment into the cache with the new value
 %% @end

--- a/src/cfclient_evaluator.erl
+++ b/src/cfclient_evaluator.erl
@@ -157,31 +157,33 @@ is_rule_included_or_excluded([Head | Tail], Target) ->
       Group = cfclient_cache_repository:get_from_cache({segment, GroupName}, CachePid),
       TargetIdentifier = maps:get(identifier, Target),
       %% First check if the target is explicitly excluded.
-      IsExcluded = is_target_in_list({excluded, false},TargetIdentifier, maps:get(excluded, Group, [])),
+      {excluded, Result} = is_target_in_list(true, {excluded, false},TargetIdentifier, maps:get(excluded, Group, [])),
       %% If Target is not excluded, check if it has been explicitly included
-      IsIncluded = is_target_in_list({included, false},TargetIdentifier, maps:get(included, Group, []));
+      IsIncluded = is_target_in_list(Result == false, {included, false},TargetIdentifier, maps:get(included, Group, []));
     _ -> is_rule_included_or_excluded(Tail, Target)
   end;
 is_rule_included_or_excluded([], _) -> false.
 
--spec is_target_in_list(RulesType :: {atom(), atom()}, TargetIdentifier :: binary(), GroupRules :: list()) -> true | false.
-is_target_in_list({excluded, false}, TargetIdentifier, [Head | Tail]) ->
+-spec is_target_in_list(ShouldSearch :: boolean(), RulesType :: {atom(), atom()}, TargetIdentifier :: binary(), GroupRules :: list()) -> true | false.
+is_target_in_list(true, {excluded, false}, TargetIdentifier, [Head | Tail]) ->
   ListTargetIdentifier = maps:get(identifier, Head),
   if
     TargetIdentifier == ListTargetIdentifier ->
       {excluded, true};
-    true -> is_target_in_list({excluded, false}, TargetIdentifier, Tail)
+    true -> is_target_in_list(true, {excluded, false}, TargetIdentifier, Tail)
   end;
-is_target_in_list({included, false}, TargetIdentifier, [Head | Tail]) ->
+is_target_in_list(true, {included, false}, TargetIdentifier, [Head | Tail]) ->
   ListTargetIdentifier = maps:get(identifier, Head),
   if
     TargetIdentifier == ListTargetIdentifier ->
       {included, true};
-    true -> is_target_in_list({included, false}, TargetIdentifier, Tail)
+    true -> is_target_in_list(true, {included, false}, TargetIdentifier, Tail)
   end;
-is_target_in_list({excluded, true}, _, _) -> {excluded, true};
-is_target_in_list({included, true}, _, _) -> {included, true};
-is_target_in_list({Type, false}, _, []) -> {Type, false}.
+%% Return excluded if we shouldn't search when evaluating included rules, as that means we've matched on an Excluded rule
+is_target_in_list(false, {included, false}, _, _) -> {excluded, true};
+%% Remaining functions here are when the search has finished and didn't find a match on any respective rule types.
+is_target_in_list(true, {excluded, false}, _, []) -> {excluded, false};
+is_target_in_list(true, {included, false}, _, []) -> {included, false}.
 
 -spec bool_variation(Identifier :: binary(), Target :: target()) -> {ok, boolean()} | not_ok.
 bool_variation(FlagIdentifier, Target) ->

--- a/src/cfclient_evaluator.erl
+++ b/src/cfclient_evaluator.erl
@@ -172,8 +172,7 @@ number_variation(FlagIdentifier, Target, DefaultValue) ->
   end.
 
 
-%% TODO - not implemented
--spec json_variation(Identifier :: binary(), Target :: target(), DefaultValue :: binary()) -> binary().
+-spec json_variation(Identifier :: binary(), Target :: target(), DefaultValue :: map()) -> map().
 json_variation(FlagIdentifier, Target, DefaultValue) ->
   Variation = evaluate_flag(FlagIdentifier, Target),
   jsx:decode(Variation, []).

--- a/src/cfclient_evaluator.erl
+++ b/src/cfclient_evaluator.erl
@@ -20,7 +20,7 @@ attributes := #{atom() := any()}
 evaluate_flag(FlagIdentifier, Target) ->
   CachePid = cfclient_cache_repository:get_pid(),
   case cfclient_cache_repository:get_from_cache({flag, FlagIdentifier}, CachePid) of
-    Flag ->
+    #{} = Flag ->
       State = maps:get(state, Flag),
       if
       %% If flag is turned off we always return default off variation

--- a/src/cfclient_evaluator.erl
+++ b/src/cfclient_evaluator.erl
@@ -5,7 +5,7 @@
 %%%-------------------------------------------------------------------
 -module(cfclient_evaluator).
 
--export([bool_variation/3, string_variation/3, number_variation/3]).
+-export([bool_variation/3, string_variation/3, number_variation/3, json_variation/3]).
 
 -type target() ::
 #{identifier := binary(),
@@ -175,7 +175,8 @@ number_variation(FlagIdentifier, Target, DefaultValue) ->
 %% TODO - not implemented
 -spec json_variation(Identifier :: binary(), Target :: target(), DefaultValue :: binary()) -> binary().
 json_variation(FlagIdentifier, Target, DefaultValue) ->
-  not_implemented.
+  Variation = evaluate_flag(FlagIdentifier, Target),
+  jsx:decode(Variation, []).
 
 
 %% TODO - refactor using recursion so can exit upon condition.

--- a/src/cfclient_evaluator.erl
+++ b/src/cfclient_evaluator.erl
@@ -160,10 +160,11 @@ is_rule_included_or_excluded([Head | Tail], Target) ->
       IsExcluded = is_target_in_list(TargetIdentifier, maps:get(excluded, Group, [])),
       %% If Target is not excluded, check if it has been explicitly included
       if
-        IsExcluded == false ->
+        IsExcluded == true ->
+          {excluded, true};
+        true ->
           IsIncluded = is_target_in_list(TargetIdentifier, maps:get(included, Group, [])),
-          {included, IsIncluded};
-        true -> {excluded, IsExcluded}
+          {included, IsIncluded}
       end;
     _ -> is_rule_included_or_excluded(Tail, Target)
   end;

--- a/src/cfclient_evaluator.erl
+++ b/src/cfclient_evaluator.erl
@@ -5,7 +5,7 @@
 %%%-------------------------------------------------------------------
 -module(cfclient_evaluator).
 
--export([bool_variation/3, string_variation/3, number_variation/3, json_variation/3]).
+-export([bool_variation/2, string_variation/2, number_variation/2, json_variation/2]).
 
 -type target() ::
 #{identifier := binary(),
@@ -158,16 +158,16 @@ is_target_in_list(Found, TargetIdentifier, [Head | Tail]) when Found /= true ->
 is_target_in_list(_, _, _) -> false;
 is_target_in_list(_, _, []) -> false.
 
--spec bool_variation(Identifier :: binary(), Target :: target(), DefaultValue :: boolean()) -> {ok, boolean()} | not_ok.
-bool_variation(FlagIdentifier, Target, DefaultValue) ->
+-spec bool_variation(Identifier :: binary(), Target :: target()) -> {ok, boolean()} | not_ok.
+bool_variation(FlagIdentifier, Target) ->
   case evaluate_flag(FlagIdentifier, Target) of
     {ok, Variation} ->
       {ok, binary_to_list(Variation) == "true"};
     not_ok -> not_ok
   end.
 
--spec string_variation(Identifier :: binary(), Target :: target(), DefaultValue :: binary()) -> {ok, string()} | not_ok.
-string_variation(FlagIdentifier, Target, DefaultValue) ->
+-spec string_variation(Identifier :: binary(), Target :: target()) -> {ok, string()} | not_ok.
+string_variation(FlagIdentifier, Target) ->
   case evaluate_flag(FlagIdentifier, Target) of
     {ok, Variation} ->
       {ok, binary_to_list(Variation)};
@@ -175,8 +175,8 @@ string_variation(FlagIdentifier, Target, DefaultValue) ->
   end.
 
 
--spec number_variation(Identifier :: binary(), Target :: target(), DefaultValue :: binary()) -> {ok, number()} | not_ok.
-number_variation(FlagIdentifier, Target, DefaultValue) ->
+-spec number_variation(Identifier :: binary(), Target :: target()) -> {ok, number()} | not_ok.
+number_variation(FlagIdentifier, Target) ->
   case evaluate_flag(FlagIdentifier, Target) of
     {ok, Variation} ->
       try {ok, binary_to_float(Variation)}
@@ -187,8 +187,8 @@ number_variation(FlagIdentifier, Target, DefaultValue) ->
   end.
 
 
--spec json_variation(Identifier :: binary(), Target :: target(), DefaultValue :: map()) -> {ok, map()} | not_ok.
-json_variation(FlagIdentifier, Target, DefaultValue) ->
+-spec json_variation(Identifier :: binary(), Target :: target()) -> {ok, map()} | not_ok.
+json_variation(FlagIdentifier, Target) ->
   case evaluate_flag(FlagIdentifier, Target) of
     {ok, Variation} ->
       {ok, jsx:decode(Variation, [])};

--- a/src/cfclient_evaluator.erl
+++ b/src/cfclient_evaluator.erl
@@ -206,7 +206,13 @@ number_variation(FlagIdentifier, Target) ->
 json_variation(FlagIdentifier, Target) ->
   case evaluate_flag(FlagIdentifier, Target) of
     {ok, Variation} ->
-      {ok, jsx:decode(Variation, [])};
+      try
+        {ok, jsx:decode(Variation, [])}
+      catch
+        error:badarg ->
+          logger:error("Error when decoding Json variation. Not returning variation for: ~p~n" , [Variation]),
+          not_ok
+      end;
     not_ok -> not_ok
   end.
 

--- a/src/cfclient_evaluator_test.erl
+++ b/src/cfclient_evaluator_test.erl
@@ -35,14 +35,14 @@ variations_test() ->
   %%-------------------- Bool Variation --------------------
   %%%%%%%% Flag is off %%%%%%%%
   meck:expect(lru, get, fun(CacheName, <<"flags/My_boolean_flag">>) -> boolean_flag_off() end),
-  ?assertEqual({ok,false}, cfclient_evaluator:bool_variation(<<"My_boolean_flag">>, ExistingTargetA, false)),
+  ?assertEqual({ok,false}, cfclient_evaluator:bool_variation(<<"My_boolean_flag">>, ExistingTargetA)),
 
   %%%%%%%% Flag is on with a single target %%%%%%%%
   meck:expect(lru, get, fun(CacheName, <<"flags/My_boolean_flag">>) -> boolean_flag_single_target() end),
   %% Target found
-  ?assertEqual({ok,false}, cfclient_evaluator:bool_variation(<<"My_boolean_flag">>, ExistingTargetA, false)),
+  ?assertEqual({ok,false}, cfclient_evaluator:bool_variation(<<"My_boolean_flag">>, ExistingTargetA)),
   %% Target not found
-  ?assertEqual({ok,true}, cfclient_evaluator:bool_variation(<<"My_boolean_flag">>, NonExistentTarget, false)),
+  ?assertEqual({ok,true}, cfclient_evaluator:bool_variation(<<"My_boolean_flag">>, NonExistentTarget)),
 
   %%%%%%%% Flag is on - no targets - but Groups %%%%%%%%
   meck:expect(lru, get, fun
@@ -51,10 +51,10 @@ variations_test() ->
                         end),
 
   %% Target excluded
-  ?assertEqual({ok,true}, cfclient_evaluator:bool_variation(<<"My_boolean_flag">>, TargetExcludedFromGroup, false)),
+  ?assertEqual({ok,true}, cfclient_evaluator:bool_variation(<<"My_boolean_flag">>, TargetExcludedFromGroup)),
 
   %% Target included
-  ?assertEqual({ok,false}, cfclient_evaluator:bool_variation(<<"My_boolean_flag">>, TargetIncludedFromGroup, false)),
+  ?assertEqual({ok,false}, cfclient_evaluator:bool_variation(<<"My_boolean_flag">>, TargetIncludedFromGroup)),
 
   %%%%%%%% Flag is on - no targets or groups %%%%%%%%
   %% Default on variation
@@ -62,29 +62,29 @@ variations_test() ->
                           (CacheName, <<"segments/target_group_1">>) -> target_group_no_custom_rules();
                           (CacheName, <<"flags/My_boolean_flag">>) -> boolean_flag_no_targets_or_groups()
                         end),
-  ?assertEqual({ok,true}, cfclient_evaluator:bool_variation(<<"My_boolean_flag">>, TargetExcludedFromGroup, false)),
+  ?assertEqual({ok,true}, cfclient_evaluator:bool_variation(<<"My_boolean_flag">>, TargetExcludedFromGroup)),
 
 
   %%-------------------- String Variation --------------------
   %%%%%%%% Flag is off %%%%%%%%
   meck:expect(lru, get, fun(CacheName, <<"flags/My_string_flag">>) -> string_flag_off() end),
-  ?assertEqual({ok,"don't serve it"}, cfclient_evaluator:string_variation(<<"My_string_flag">>, ExistingTargetA, "some_fake_default_value")),
+  ?assertEqual({ok,"don't serve it"}, cfclient_evaluator:string_variation(<<"My_string_flag">>, ExistingTargetA)),
 
   %%%%%%%% Flag is on with a single target %%%%%%%%
   meck:expect(lru, get, fun
                           (CacheName, <<"segments/target_group_1">>) -> target_group_no_custom_rules();
                           (CacheName, <<"flags/My_string_flag">>) -> string_flag_target_and_groups()
                         end),  %% Target found
-  ?assertEqual({ok, "don't serve it"}, cfclient_evaluator:string_variation(<<"My_string_flag">>, ExistingTargetA, "some_fake_default_value")),
+  ?assertEqual({ok, "don't serve it"}, cfclient_evaluator:string_variation(<<"My_string_flag">>, ExistingTargetA)),
   %% Target not found
-  ?assertEqual({ok, "serve it"}, cfclient_evaluator:string_variation(<<"My_string_flag">>, NonExistentTarget, "some_fake_default_value")),
+  ?assertEqual({ok, "serve it"}, cfclient_evaluator:string_variation(<<"My_string_flag">>, NonExistentTarget)),
 
   %%%%%% Flag is on - no targets - but Groups %%%%%%%%
   %% Target excluded
-  ?assertEqual({ok, "serve it"}, cfclient_evaluator:string_variation(<<"My_string_flag">>, TargetExcludedFromGroup, "some_fake_default_value")),
+  ?assertEqual({ok, "serve it"}, cfclient_evaluator:string_variation(<<"My_string_flag">>, TargetExcludedFromGroup)),
 
   %% Target included
-  ?assertEqual({ok, "don't serve it"}, cfclient_evaluator:string_variation(<<"My_string_flag">>, TargetIncludedFromGroup, "some_fake_default_value")),
+  ?assertEqual({ok, "don't serve it"}, cfclient_evaluator:string_variation(<<"My_string_flag">>, TargetIncludedFromGroup)),
 
   %%%%%%%% Flag is on - no targets or groups %%%%%%%%
   %% Default on variation
@@ -92,12 +92,12 @@ variations_test() ->
                           (CacheName, <<"segments/target_group_1">>) -> target_group_no_custom_rules();
                           (CacheName, <<"flags/My_string_flag">>) -> string_flag_no_targets_or_groups()
                         end),
-  ?assertEqual({ok, "serve it"}, cfclient_evaluator:string_variation(<<"My_string_flag">>, ExistingTargetA, false)),
+  ?assertEqual({ok, "serve it"}, cfclient_evaluator:string_variation(<<"My_string_flag">>, ExistingTargetA)),
 
   %%-------------------- Number Variation --------------------
   %%%%%%%% Flag is off %%%%%%%%
   meck:expect(lru, get, fun(CacheName, <<"flags/My_cool_number_flag">>) -> number_flag_off() end),
-  ?assertEqual({ok, 0}, cfclient_evaluator:number_variation(<<"My_cool_number_flag">>, ExistingTargetA, 23423452354)),
+  ?assertEqual({ok, 0}, cfclient_evaluator:number_variation(<<"My_cool_number_flag">>, ExistingTargetA)),
 
   %%%%%%%% Flag is on with a single target %%%%%%%%
   meck:expect(lru, get, fun
@@ -105,9 +105,9 @@ variations_test() ->
                           (CacheName, <<"flags/My_cool_number_flag">>) -> number_flag_only_targets()
                         end),
   %% Target found
-  ?assertEqual({ok, 0}, cfclient_evaluator:number_variation(<<"My_cool_number_flag">>, ExistingTargetA, 23423452354)),
+  ?assertEqual({ok, 0}, cfclient_evaluator:number_variation(<<"My_cool_number_flag">>, ExistingTargetA)),
   %% Target not found
-  ?assertEqual({ok, 12456}, cfclient_evaluator:number_variation(<<"My_cool_number_flag">>, NonExistentTarget, 23423452354)),
+  ?assertEqual({ok, 12456}, cfclient_evaluator:number_variation(<<"My_cool_number_flag">>, NonExistentTarget)),
 
   %%%%%% Flag is on - no targets - but Groups %%%%%%%%
   meck:expect(lru, get, fun
@@ -115,10 +115,10 @@ variations_test() ->
                           (CacheName, <<"flags/My_cool_number_flag">>) -> number_flag_only_groups()
                         end),
   %% Target excluded
-  ?assertEqual({ok, 12456}, cfclient_evaluator:number_variation(<<"My_cool_number_flag">>, TargetExcludedFromGroup, 23423452354)),
+  ?assertEqual({ok, 12456}, cfclient_evaluator:number_variation(<<"My_cool_number_flag">>, TargetExcludedFromGroup)),
 
   %% Target Included
-  ?assertEqual({ok, 0.001}, cfclient_evaluator:number_variation(<<"My_cool_number_flag">>, TargetIncludedFromGroup, 23423452354)),
+  ?assertEqual({ok, 0.001}, cfclient_evaluator:number_variation(<<"My_cool_number_flag">>, TargetIncludedFromGroup)),
 
   %%%%%%%% Flag is on - no targets or groups %%%%%%%%
   %% Default on variation
@@ -126,12 +126,12 @@ variations_test() ->
                           (CacheName, <<"segments/target_group_1">>) -> target_group_no_custom_rules();
                           (CacheName, <<"flags/My_cool_number_flag">>) -> number_flag_no_targets_or_groups()
                         end),
-  ?assertEqual({ok, 12456}, cfclient_evaluator:number_variation(<<"My_cool_number_flag">>, ExistingTargetA, false)),
+  ?assertEqual({ok, 12456}, cfclient_evaluator:number_variation(<<"My_cool_number_flag">>, ExistingTargetA)),
 
   %%-------------------- JSON Variation --------------------
   %%%%%%%% Flag is off %%%%%%%%
   meck:expect(lru, get, fun(CacheName, <<"flags/My_JSON_flag">>) -> json_flag_off() end),
-  ?assertEqual({ok, #{<<"serveIt">> => <<"no">>}}, cfclient_evaluator:json_variation(<<"My_JSON_flag">>, ExistingTargetA, #{<<"someDefaultValue">> => <<"default!">>})),
+  ?assertEqual({ok, #{<<"serveIt">> => <<"no">>}}, cfclient_evaluator:json_variation(<<"My_JSON_flag">>, ExistingTargetA)),
 
   %%%%%%%% Flag is on with a single target %%%%%%%%
   meck:expect(lru, get, fun
@@ -139,9 +139,9 @@ variations_test() ->
                           (CacheName, <<"flags/My_JSON_flag">>) -> json_flag_only_targets()
                         end),
   %% Target found
-  ?assertEqual({ok, #{<<"serveIt">> => <<"no">>}}, cfclient_evaluator:json_variation(<<"My_JSON_flag">>, ExistingTargetA, #{<<"someDefaultValue">> => <<"default!">>})),
+  ?assertEqual({ok, #{<<"serveIt">> => <<"no">>}}, cfclient_evaluator:json_variation(<<"My_JSON_flag">>, ExistingTargetA)),
   %% Target not found
-  ?assertEqual({ok, #{<<"serveIt">> => <<"yes">>}}, cfclient_evaluator:json_variation(<<"My_JSON_flag">>, NonExistentTarget, #{<<"someDefaultValue">> => <<"default!">>})),
+  ?assertEqual({ok, #{<<"serveIt">> => <<"yes">>}}, cfclient_evaluator:json_variation(<<"My_JSON_flag">>, NonExistentTarget)),
 
   %%%%%% Flag is on - no targets - but Groups %%%%%%%%
   meck:expect(lru, get, fun
@@ -149,10 +149,10 @@ variations_test() ->
                           (CacheName, <<"flags/My_JSON_flag">>) -> json_flag_only_groups()
                         end),
   %% Target excluded
-  ?assertEqual({ok, #{<<"serveIt">> => <<"yes">>}}, cfclient_evaluator:json_variation(<<"My_JSON_flag">>, TargetExcludedFromGroup, #{<<"someDefaultValue">> => <<"default!">>})),
+  ?assertEqual({ok, #{<<"serveIt">> => <<"yes">>}}, cfclient_evaluator:json_variation(<<"My_JSON_flag">>, TargetExcludedFromGroup)),
 
   %% Target Included
-  ?assertEqual({ok, #{<<"serveIt">> => <<"maybe">>}}, cfclient_evaluator:json_variation(<<"My_JSON_flag">>, TargetIncludedFromGroup, #{<<"someDefaultValue">> => <<"default!">>})),
+  ?assertEqual({ok, #{<<"serveIt">> => <<"maybe">>}}, cfclient_evaluator:json_variation(<<"My_JSON_flag">>, TargetIncludedFromGroup)),
 
 
   %%%%%%%% Flag is on - no targets or groups %%%%%%%%
@@ -161,7 +161,7 @@ variations_test() ->
                           (CacheName, <<"segments/target_group_1">>) -> target_group_no_custom_rules();
                           (CacheName, <<"flags/My_JSON_flag">>) -> json_flag_no_targets_or_groups()
                         end),
-  ?assertEqual({ok, #{<<"serveIt">> => <<"yes">>}}, cfclient_evaluator:json_variation(<<"My_JSON_flag">>, ExistingTargetA, #{<<"someDefaultValue">> => <<"default!">>})),
+  ?assertEqual({ok, #{<<"serveIt">> => <<"yes">>}}, cfclient_evaluator:json_variation(<<"My_JSON_flag">>, ExistingTargetA)),
 
   meck:unload(lru).
 

--- a/src/cfclient_evaluator_test.erl
+++ b/src/cfclient_evaluator_test.erl
@@ -35,14 +35,14 @@ variations_test() ->
   %%-------------------- Bool Variation --------------------
   %%%%%%%% Flag is off %%%%%%%%
   meck:expect(lru, get, fun(CacheName, <<"flags/My_boolean_flag">>) -> boolean_flag_off() end),
-  ?assertEqual(false, cfclient_evaluator:bool_variation(<<"My_boolean_flag">>, ExistingTargetA, false)),
+  ?assertEqual({ok,false}, cfclient_evaluator:bool_variation(<<"My_boolean_flag">>, ExistingTargetA, false)),
 
   %%%%%%%% Flag is on with a single target %%%%%%%%
   meck:expect(lru, get, fun(CacheName, <<"flags/My_boolean_flag">>) -> boolean_flag_single_target() end),
   %% Target found
-  ?assertEqual(false, cfclient_evaluator:bool_variation(<<"My_boolean_flag">>, ExistingTargetA, false)),
+  ?assertEqual({ok,false}, cfclient_evaluator:bool_variation(<<"My_boolean_flag">>, ExistingTargetA, false)),
   %% Target not found
-  ?assertEqual(true, cfclient_evaluator:bool_variation(<<"My_boolean_flag">>, NonExistentTarget, false)),
+  ?assertEqual({ok,true}, cfclient_evaluator:bool_variation(<<"My_boolean_flag">>, NonExistentTarget, false)),
 
   %%%%%%%% Flag is on - no targets - but Groups %%%%%%%%
   meck:expect(lru, get, fun
@@ -51,10 +51,10 @@ variations_test() ->
                         end),
 
   %% Target excluded
-  ?assertEqual(true, cfclient_evaluator:bool_variation(<<"My_boolean_flag">>, TargetExcludedFromGroup, false)),
+  ?assertEqual({ok,true}, cfclient_evaluator:bool_variation(<<"My_boolean_flag">>, TargetExcludedFromGroup, false)),
 
   %% Target included
-  ?assertEqual(false, cfclient_evaluator:bool_variation(<<"My_boolean_flag">>, TargetIncludedFromGroup, false)),
+  ?assertEqual({ok,false}, cfclient_evaluator:bool_variation(<<"My_boolean_flag">>, TargetIncludedFromGroup, false)),
 
   %%%%%%%% Flag is on - no targets or groups %%%%%%%%
   %% Default on variation
@@ -62,29 +62,29 @@ variations_test() ->
                           (CacheName, <<"segments/target_group_1">>) -> target_group_no_custom_rules();
                           (CacheName, <<"flags/My_boolean_flag">>) -> boolean_flag_no_targets_or_groups()
                         end),
-  ?assertEqual(true, cfclient_evaluator:bool_variation(<<"My_boolean_flag">>, TargetExcludedFromGroup, false)),
+  ?assertEqual({ok,true}, cfclient_evaluator:bool_variation(<<"My_boolean_flag">>, TargetExcludedFromGroup, false)),
 
 
   %%-------------------- String Variation --------------------
   %%%%%%%% Flag is off %%%%%%%%
   meck:expect(lru, get, fun(CacheName, <<"flags/My_string_flag">>) -> string_flag_off() end),
-  ?assertEqual("don't serve it", cfclient_evaluator:string_variation(<<"My_string_flag">>, ExistingTargetA, "some_fake_default_value")),
+  ?assertEqual({ok,"don't serve it"}, cfclient_evaluator:string_variation(<<"My_string_flag">>, ExistingTargetA, "some_fake_default_value")),
 
   %%%%%%%% Flag is on with a single target %%%%%%%%
   meck:expect(lru, get, fun
                           (CacheName, <<"segments/target_group_1">>) -> target_group_no_custom_rules();
                           (CacheName, <<"flags/My_string_flag">>) -> string_flag_target_and_groups()
                         end),  %% Target found
-  ?assertEqual("don't serve it", cfclient_evaluator:string_variation(<<"My_string_flag">>, ExistingTargetA, "some_fake_default_value")),
+  ?assertEqual({ok, "don't serve it"}, cfclient_evaluator:string_variation(<<"My_string_flag">>, ExistingTargetA, "some_fake_default_value")),
   %% Target not found
-  ?assertEqual("serve it", cfclient_evaluator:string_variation(<<"My_string_flag">>, NonExistentTarget, "some_fake_default_value")),
+  ?assertEqual({ok, "serve it"}, cfclient_evaluator:string_variation(<<"My_string_flag">>, NonExistentTarget, "some_fake_default_value")),
 
   %%%%%% Flag is on - no targets - but Groups %%%%%%%%
   %% Target excluded
-  ?assertEqual("serve it", cfclient_evaluator:string_variation(<<"My_string_flag">>, TargetExcludedFromGroup, "some_fake_default_value")),
+  ?assertEqual({ok, "serve it"}, cfclient_evaluator:string_variation(<<"My_string_flag">>, TargetExcludedFromGroup, "some_fake_default_value")),
 
   %% Target included
-  ?assertEqual("don't serve it", cfclient_evaluator:string_variation(<<"My_string_flag">>, TargetIncludedFromGroup, "some_fake_default_value")),
+  ?assertEqual({ok, "don't serve it"}, cfclient_evaluator:string_variation(<<"My_string_flag">>, TargetIncludedFromGroup, "some_fake_default_value")),
 
   %%%%%%%% Flag is on - no targets or groups %%%%%%%%
   %% Default on variation
@@ -92,12 +92,12 @@ variations_test() ->
                           (CacheName, <<"segments/target_group_1">>) -> target_group_no_custom_rules();
                           (CacheName, <<"flags/My_string_flag">>) -> string_flag_no_targets_or_groups()
                         end),
-  ?assertEqual("serve it", cfclient_evaluator:string_variation(<<"My_string_flag">>, ExistingTargetA, false)),
+  ?assertEqual({ok, "serve it"}, cfclient_evaluator:string_variation(<<"My_string_flag">>, ExistingTargetA, false)),
 
   %%-------------------- Number Variation --------------------
   %%%%%%%% Flag is off %%%%%%%%
   meck:expect(lru, get, fun(CacheName, <<"flags/My_cool_number_flag">>) -> number_flag_off() end),
-  ?assertEqual(0, cfclient_evaluator:number_variation(<<"My_cool_number_flag">>, ExistingTargetA, 23423452354)),
+  ?assertEqual({ok, 0}, cfclient_evaluator:number_variation(<<"My_cool_number_flag">>, ExistingTargetA, 23423452354)),
 
   %%%%%%%% Flag is on with a single target %%%%%%%%
   meck:expect(lru, get, fun
@@ -105,9 +105,9 @@ variations_test() ->
                           (CacheName, <<"flags/My_cool_number_flag">>) -> number_flag_only_targets()
                         end),
   %% Target found
-  ?assertEqual(0, cfclient_evaluator:number_variation(<<"My_cool_number_flag">>, ExistingTargetA, 23423452354)),
+  ?assertEqual({ok, 0}, cfclient_evaluator:number_variation(<<"My_cool_number_flag">>, ExistingTargetA, 23423452354)),
   %% Target not found
-  ?assertEqual(12456, cfclient_evaluator:number_variation(<<"My_cool_number_flag">>, NonExistentTarget, 23423452354)),
+  ?assertEqual({ok, 12456}, cfclient_evaluator:number_variation(<<"My_cool_number_flag">>, NonExistentTarget, 23423452354)),
 
   %%%%%% Flag is on - no targets - but Groups %%%%%%%%
   meck:expect(lru, get, fun
@@ -115,10 +115,10 @@ variations_test() ->
                           (CacheName, <<"flags/My_cool_number_flag">>) -> number_flag_only_groups()
                         end),
   %% Target excluded
-  ?assertEqual(12456, cfclient_evaluator:number_variation(<<"My_cool_number_flag">>, TargetExcludedFromGroup, 23423452354)),
+  ?assertEqual({ok, 12456}, cfclient_evaluator:number_variation(<<"My_cool_number_flag">>, TargetExcludedFromGroup, 23423452354)),
 
   %% Target Included
-  ?assertEqual(0.001, cfclient_evaluator:number_variation(<<"My_cool_number_flag">>, TargetIncludedFromGroup, 23423452354)),
+  ?assertEqual({ok, 0.001}, cfclient_evaluator:number_variation(<<"My_cool_number_flag">>, TargetIncludedFromGroup, 23423452354)),
 
   %%%%%%%% Flag is on - no targets or groups %%%%%%%%
   %% Default on variation
@@ -126,12 +126,12 @@ variations_test() ->
                           (CacheName, <<"segments/target_group_1">>) -> target_group_no_custom_rules();
                           (CacheName, <<"flags/My_cool_number_flag">>) -> number_flag_no_targets_or_groups()
                         end),
-  ?assertEqual(12456, cfclient_evaluator:number_variation(<<"My_cool_number_flag">>, ExistingTargetA, false)),
+  ?assertEqual({ok, 12456}, cfclient_evaluator:number_variation(<<"My_cool_number_flag">>, ExistingTargetA, false)),
 
   %%-------------------- JSON Variation --------------------
   %%%%%%%% Flag is off %%%%%%%%
   meck:expect(lru, get, fun(CacheName, <<"flags/My_JSON_flag">>) -> json_flag_off() end),
-  ?assertEqual(#{<<"serveIt">> => <<"no">>}, cfclient_evaluator:json_variation(<<"My_JSON_flag">>, ExistingTargetA, #{<<"someDefaultValue">> => <<"default!">>})),
+  ?assertEqual({ok, #{<<"serveIt">> => <<"no">>}}, cfclient_evaluator:json_variation(<<"My_JSON_flag">>, ExistingTargetA, #{<<"someDefaultValue">> => <<"default!">>})),
 
   %%%%%%%% Flag is on with a single target %%%%%%%%
   meck:expect(lru, get, fun
@@ -139,9 +139,9 @@ variations_test() ->
                           (CacheName, <<"flags/My_JSON_flag">>) -> json_flag_only_targets()
                         end),
   %% Target found
-  ?assertEqual(#{<<"serveIt">> => <<"no">>}, cfclient_evaluator:json_variation(<<"My_JSON_flag">>, ExistingTargetA, #{<<"someDefaultValue">> => <<"default!">>})),
+  ?assertEqual({ok, #{<<"serveIt">> => <<"no">>}}, cfclient_evaluator:json_variation(<<"My_JSON_flag">>, ExistingTargetA, #{<<"someDefaultValue">> => <<"default!">>})),
   %% Target not found
-  ?assertEqual(#{<<"serveIt">> => <<"yes">>}, cfclient_evaluator:json_variation(<<"My_JSON_flag">>, NonExistentTarget, #{<<"someDefaultValue">> => <<"default!">>})),
+  ?assertEqual({ok, #{<<"serveIt">> => <<"yes">>}}, cfclient_evaluator:json_variation(<<"My_JSON_flag">>, NonExistentTarget, #{<<"someDefaultValue">> => <<"default!">>})),
 
   %%%%%% Flag is on - no targets - but Groups %%%%%%%%
   meck:expect(lru, get, fun
@@ -149,10 +149,10 @@ variations_test() ->
                           (CacheName, <<"flags/My_JSON_flag">>) -> json_flag_only_groups()
                         end),
   %% Target excluded
-  ?assertEqual(#{<<"serveIt">> => <<"yes">>}, cfclient_evaluator:json_variation(<<"My_JSON_flag">>, TargetExcludedFromGroup, #{<<"someDefaultValue">> => <<"default!">>})),
+  ?assertEqual({ok, #{<<"serveIt">> => <<"yes">>}}, cfclient_evaluator:json_variation(<<"My_JSON_flag">>, TargetExcludedFromGroup, #{<<"someDefaultValue">> => <<"default!">>})),
 
   %% Target Included
-  ?assertEqual(#{<<"serveIt">> => <<"maybe">>}, cfclient_evaluator:json_variation(<<"My_JSON_flag">>, TargetIncludedFromGroup, #{<<"someDefaultValue">> => <<"default!">>})),
+  ?assertEqual({ok, #{<<"serveIt">> => <<"maybe">>}}, cfclient_evaluator:json_variation(<<"My_JSON_flag">>, TargetIncludedFromGroup, #{<<"someDefaultValue">> => <<"default!">>})),
 
 
   %%%%%%%% Flag is on - no targets or groups %%%%%%%%
@@ -161,7 +161,7 @@ variations_test() ->
                           (CacheName, <<"segments/target_group_1">>) -> target_group_no_custom_rules();
                           (CacheName, <<"flags/My_JSON_flag">>) -> json_flag_no_targets_or_groups()
                         end),
-  ?assertEqual(#{<<"serveIt">> => <<"yes">>}, cfclient_evaluator:json_variation(<<"My_JSON_flag">>, ExistingTargetA, #{<<"someDefaultValue">> => <<"default!">>})),
+  ?assertEqual({ok, #{<<"serveIt">> => <<"yes">>}}, cfclient_evaluator:json_variation(<<"My_JSON_flag">>, ExistingTargetA, #{<<"someDefaultValue">> => <<"default!">>})),
 
   meck:unload(lru).
 

--- a/src/cfclient_evaluator_test.erl
+++ b/src/cfclient_evaluator_test.erl
@@ -354,6 +354,18 @@ is_rule_included_or_excluded_test() ->
     attributes => <<"">>
   },
 
+  NotIncludedTargetA = #{'identifier' => <<"haven't_been_included_or_excluded">>,
+    name => <<"">>,
+    anonymous => <<"">>,
+    attributes => <<"">>
+  },
+
+  NotIncludedTargetB = #{'identifier' => <<"another_target_that_hasn't_been_included_or_excluded">>,
+    name => <<"">>,
+    anonymous => <<"">>,
+    attributes => <<"">>
+  },
+
 
   %% Cache data for mocked cache call
   CacheName = cfclient_cache_repository:get_cache_name(),
@@ -379,14 +391,19 @@ is_rule_included_or_excluded_test() ->
 
   %% Excluded %%
   meck:expect(lru, get, fun(CacheName, <<"segments/target_group_1">>) -> CachedGroup end),
-  ?assertEqual(false, cfclient_evaluator:is_rule_included_or_excluded(Clauses, ExcludedTarget)),
-  ?assertEqual(false, cfclient_evaluator:is_rule_included_or_excluded(Clauses, ExcludedTargetB)),
+  ?assertEqual({excluded,true}, cfclient_evaluator:is_rule_included_or_excluded(Clauses, ExcludedTarget)),
+  ?assertEqual({excluded,true}, cfclient_evaluator:is_rule_included_or_excluded(Clauses, ExcludedTargetB)),
 
 
-%% Included %%
+  %% Included %%
   meck:expect(lru, get, fun(CacheName, <<"segments/target_group_1">>) -> CachedGroup end),
-  ?assertEqual(true, cfclient_evaluator:is_rule_included_or_excluded(Clauses, IncludedTargetA)),
-  ?assertEqual(true, cfclient_evaluator:is_rule_included_or_excluded(Clauses, IncludedTargetB)),
+  ?assertEqual({included,true}, cfclient_evaluator:is_rule_included_or_excluded(Clauses, IncludedTargetA)),
+  ?assertEqual({included,true}, cfclient_evaluator:is_rule_included_or_excluded(Clauses, IncludedTargetB)),
+
+  %% Not Included %%
+  meck:expect(lru, get, fun(CacheName, <<"segments/target_group_1">>) -> CachedGroup end),
+  ?assertEqual({included,false}, cfclient_evaluator:is_rule_included_or_excluded(Clauses, NotIncludedTargetA)),
+  ?assertEqual({included,false}, cfclient_evaluator:is_rule_included_or_excluded(Clauses, NotIncludedTargetB)),
 
   meck:unload(lru).
 


### PR DESCRIPTION
Ticket: https://harness.atlassian.net/browse/FFM-4692

This PR adds string/number/json Client Variation functions, and improvements in two areas:

1. Evaluations module now returns a tuple of `{ok, Variation}` if the Variation was successful, or a `not_ok` atom if something went wrong that was accounted for - then the Client will log this and return the user supplied variation function

2. If an unexpected runtime error occurs, the Client Variation functions include exception handling and logging to return the user supplied Default variation.

