### PR TITLE
FFM-5139 Return Tuple in Public Variation functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,8 +79,9 @@ ok
 2> Target = #{identifier => list_to_binary("Demo"), name => list_to_binary("demo"), anonymous => false, attributes => #{}}.       
   #{anonymous => false,attributes => #{},
   identifier => <<"Demo">>,name => <<"demo">>}
-3> cfclient:bool_variation("harnessappdemodarkmode", Target, false). 
-  false
+3> {ok, Variation} = cfclient:bool_variation("harnessappdemodarkmode", Target, false),
+4> Variation.
+5> false
 ```
 
 ## Cleanup

--- a/src/cfclient.erl
+++ b/src/cfclient.erl
@@ -26,15 +26,16 @@ bool_variation(FlagKey, Target, Default) when is_list(FlagKey) ->
 bool_variation(FlagKey, Target, Default) when is_binary(FlagKey)->
   try
     case cfclient_evaluator:bool_variation(FlagKey, Target) of
-      {ok, Variation} -> Variation;
+      {ok, Variation} ->
+        {ok, Variation};
       not_ok ->
         logger:error("Couldn't do evaluation for Flag: ~p~n \n Target ~p~n \n Returning user supplied Default" , [FlagKey, Target]),
-        Default
+        {not_ok, Default}
     end
   catch
     _:_:Stacktrace ->
       logger:error("Error when doing bool variation for Flag: ~p~n \n Target: ~p~n \n Error: ~p~n \n Returning user supplied Default" , [FlagKey, Target, Stacktrace]),
-      Default
+      {not_ok, Default}
   end.
 
 -spec string_variation(FlagKey :: binary() | list(), Target :: cfclient_evaluator:target(), Default :: binary()) -> binary().
@@ -43,15 +44,16 @@ string_variation(FlagKey, Target, Default) when is_list(FlagKey) ->
 string_variation(FlagKey, Target, Default) when is_binary(FlagKey) ->
   try
     case cfclient_evaluator:string_variation(FlagKey, Target) of
-      {ok, Variation} -> Variation;
+      {ok, Variation} ->
+        {ok, Variation};
       not_ok ->
         logger:error("Couldn't do evaluation for Flag: ~p~n \n Target ~p~n \n Returning user supplied Default" , [FlagKey, Target]),
-        Default
+        {not_ok, Default}
     end
   catch
     _:_:Stacktrace ->
       logger:error("Unknown Error when doing bool variation for Flag: ~p~n \n Target: ~p~n \n Error: ~p~n \n Returning user supplied Default" , [FlagKey, Target, Stacktrace]),
-      Default
+      {not_ok, Default}
   end.
 
 -spec number_variation(FlagKey :: binary() | list(), Target :: cfclient_evaluator:target(), Default :: number()) -> number().
@@ -60,15 +62,16 @@ number_variation(FlagKey, Target, Default) when is_list(FlagKey) ->
 number_variation(FlagKey, Target, Default) when is_binary(FlagKey) ->
   try
     case cfclient_evaluator:number_variation(FlagKey, Target) of
-      {ok, Variation} -> Variation;
+      {ok, Variation} ->
+        {ok, Variation};
       not_ok ->
         logger:error("Couldn't do evaluation for Flag: ~p~n \n Target ~p~n \n Returning user supplied Default" , [FlagKey, Target]),
-        Default
+        {not_ok, Default}
     end
   catch
     _:_:Stacktrace ->
       logger:error("Error when doing bool variation for Flag: ~p~n \n Target: ~p~n \n Error: ~p~n \n Returning user supplied Default" , [FlagKey, Target, Stacktrace]),
-      Default
+      {not_ok, Default}
   end.
 
 -spec json_variation(FlagKey :: binary() | list(), Target :: cfclient_evaluator:target(), Default :: map()) -> map().
@@ -77,15 +80,16 @@ json_variation(FlagKey, Target, Default) when is_list(FlagKey) ->
 json_variation(FlagKey, Target, Default) when is_binary(FlagKey) ->
   try
     case cfclient_evaluator:json_variation(FlagKey, Target) of
-      {ok, Variation} -> Variation;
+      {ok, Variation} ->
+        {ok, Variation};
       not_ok ->
         logger:error("Couldn't do evaluation for Flag: ~p~n \n Target ~p~n \n Returning user supplied Default" , [FlagKey, Target]),
-        Default
+        {not_ok, Default}
     end
   catch
     _:_:Stacktrace ->
       logger:error("Error when doing bool variation for Flag: ~p~n \n Target: ~p~n \n Error: ~p~n \n Returning user supplied Default" , [FlagKey, Target, Stacktrace]),
-      Default
+      {not_ok, Default}
   end.
 
 


### PR DESCRIPTION
WHAT

If a Variation fails and we have to return the user supplied `DefaultVariation`, we previoulsy only error logged this and returned the value to the user. This PR changes that so that on top of logging the error, we return a tuple which indicates if the variation was successful or not.

WHY

Better UX for customer, who can decide what they want to do if a variation fails. Either accept default or do something else.

TICKET

https://harness.atlassian.net/browse/FFM-5139