### PR TITLE
Refactor Evaluators to be more Readable and Maintainable

### DIFF
--- a/src/cfclient_evaluator_test.erl
+++ b/src/cfclient_evaluator_test.erl
@@ -408,7 +408,22 @@ is_rule_included_or_excluded_test() ->
   meck:unload(lru).
 
 
-
+distribution_test() ->
+  #{rules =>
+  [#{clauses =>
+  [#{attribute => <<>>,
+    id => <<"e974bb15-08be-45aa-a36d-d6431ae1bfe1">>,
+    negate => false, op => <<"segmentMatch">>,
+    values => [<<"target_group_1">>]}],
+    priority => 0,
+    ruleId => <<"637019fc-6f38-4e76-9211-4da166aaa488">>,
+    serve =>
+    #{distribution =>
+    #{bucketBy => <<"identifier">>,
+      variations =>
+      [#{variation => <<"true">>, weight => 50},
+        #{variation => <<"false">>, weight => 50}]}}}]},
+  ok.
 
 boolean_flag_off() ->
   #{defaultServe => #{variation => <<"true">>},


### PR DESCRIPTION
TICKET
https://harness.atlassian.net/browse/FFM-4690

WHAT

Refactor of top level evaluate flag function

WHY

When working on adding in percentage rollout logic for this ticket, I found it very difficult to add additional evaluation logic into the top level `evaluate_flag` function, as it was using hard to read and maintain "nested if" and "nested case" statements, as well as hard to reason about pattern matching. I have basically moved and simplified the conditional logic within new function clauses, which are far more readable and maintainable

TESTING

Unit tests pass
TestGrid pass (apart from expected failures on pre-reqs and custom rules