### PR TITLE
Refactor of Evaluation Pipeline

### DIFF
--- a/src/cfclient_evaluator.erl
+++ b/src/cfclient_evaluator.erl
@@ -96,21 +96,17 @@ get_target_or_group_variation(Flag, TargetVariationIdentifier) ->
       not_ok
   end.
 
-%% Check if the supplied target matches a Target rule by evaluating the Variation to Target map.
 -spec evaluate_target_rule(VariationMap :: cfapi_variation_map:cfapi_variation_map(), Target :: target()) -> binary() | not_found.
 evaluate_target_rule(VariationMap, Target) when VariationMap /= null, Target /= null ->
   TargetIdentifier = maps:get(identifier, Target),
   search_variation_map(TargetIdentifier, VariationMap);
 
-%% If no VariationMap and Target then we don't need to check Variation Map
-%% for Targets.
 evaluate_target_rule(_, _) ->
   not_found.
 
 -spec search_variation_map(TargetIdentifier :: binary(), VariationMap :: list()) -> binary() | not_found.
 search_variation_map(TargetIdentifier, [Head | Tail]) ->
   Targets = maps:get(targets, Head),
-  %% Iterate through the nested list of Targets for the current Head.
   Result = search_targets(TargetIdentifier, Targets),
   if
     Result == found ->
@@ -119,8 +115,6 @@ search_variation_map(TargetIdentifier, [Head | Tail]) ->
   end;
 search_variation_map(_TargetIdentifier, []) -> not_found.
 
-%% Helper function to search the nested Targets list contained in a Variation Map for
-%% matching Target Identifiers.
 -spec search_targets(TargetIdentifier :: binary(), Targets :: list()) -> found | not_found.
 search_targets(TargetIdentifier, [Head | Tail]) ->
   SearchResult = maps:get(identifier, Head),
@@ -132,7 +126,6 @@ search_targets(TargetIdentifier, [Head | Tail]) ->
 search_targets(_TargetIdentifier, []) -> not_found.
 
 -spec evaluate_target_group_rules(Rules :: list(), Target :: target()) -> binary() | not_found.
-%% We only want to evaluate rules if there was no Target found in the previous stage of evaluations.
 evaluate_target_group_rules(Rules, Target) ->
   %% Sort Target Group Rules by priority - 0 is highest.
   PrioritizedRules = lists:sort(
@@ -142,7 +135,6 @@ evaluate_target_group_rules(Rules, Target) ->
 
   %% Check if a target is included or excluded from the rules.
   search_rules_for_inclusion(PrioritizedRules, Target);
-%% If no rules to evaluate return the Target variation
 evaluate_target_group_rules([], _) ->
   not_found.
 
@@ -168,44 +160,39 @@ is_rule_included_or_excluded([Head | Tail], Target) ->
       CachePid = cfclient_cache_repository:get_pid(),
       Group = cfclient_cache_repository:get_from_cache({segment, GroupName}, CachePid),
       TargetIdentifier = maps:get(identifier, Target),
-      is_target_in_list(excluded, TargetIdentifier, Group);
-%%      %% First check if the target is explicitly excluded.
-%%      {_, IsExcluded} = is_target_in_list(true, {excluded, false}, TargetIdentifier, maps:get(excluded, Group, [])),
-%%      %% If Target is not excluded, check if it has been explicitly included
-%%      is_target_in_list(IsExcluded == false, {included, false}, TargetIdentifier, maps:get(included, Group, []));
+      search_group(excluded, TargetIdentifier, Group);
     _ -> is_rule_included_or_excluded(Tail, Target)
   end;
 is_rule_included_or_excluded([], _) -> false.
 
-%% Helper function that parses Group Rules for different rule types, specifically Included and Excluded rules.
-%% The ShouldSearch variable is used to stop the search from taking place if we've matched on a rule with higher precedence.
--spec is_target_in_list(RuleType :: atom(), TargetIdentifier :: binary(), Group :: map()) -> included | excluded | false.
-is_target_in_list(excluded, TargetIdentifier, Group) ->
-  case search_rule_type(TargetIdentifier, maps:get(excluded, Group, [])) of
+%% Parses Group Rules for the different rule types.
+-spec search_group(RuleType :: atom(), TargetIdentifier :: binary(), Group :: map()) -> included | excluded | false.
+search_group(excluded, TargetIdentifier, Group) ->
+  case search_group_rules(TargetIdentifier, maps:get(excluded, Group, [])) of
     true ->
       excluded;
     false ->
-      is_target_in_list(included, TargetIdentifier, Group)
+      search_group(included, TargetIdentifier, Group)
   end;
-is_target_in_list(included, TargetIdentifier, Group) ->
-  case   search_rule_type(TargetIdentifier, maps:get(included, Group, [])) of
+search_group(included, TargetIdentifier, Group) ->
+  case   search_group_rules(TargetIdentifier, maps:get(included, Group, [])) of
     true ->
       included;
     false ->
       %% TODO Custom rules clause call goes here
-      %% is_target_in_list(custom_rules, TargetIdentifier, Group)
+      %% search_group(custom_rules, TargetIdentifier, Group)
       false
   end.
 
--spec search_rule_type(TargetIdentifier :: binary(), GroupRules :: list()) -> true | false.
-search_rule_type(TargetIdentifier, [Head | Tail]) ->
+-spec search_group_rules(TargetIdentifier :: binary(), GroupRules :: list()) -> true | false.
+search_group_rules(TargetIdentifier, [Head | Tail]) ->
   ListTargetIdentifier = maps:get(identifier, Head),
   if
     TargetIdentifier == ListTargetIdentifier ->
       true;
-    true -> search_rule_type(TargetIdentifier, Tail)
+    true -> search_group_rules(TargetIdentifier, Tail)
   end;
-search_rule_type(_TargetIdentifier, []) -> false.
+search_group_rules(_TargetIdentifier, []) -> false.
 
 evaluation_distribution() ->
   implement_me.

--- a/src/cfclient_evaluator_test.erl
+++ b/src/cfclient_evaluator_test.erl
@@ -391,19 +391,19 @@ is_rule_included_or_excluded_test() ->
 
   %% Excluded %%
   meck:expect(lru, get, fun(CacheName, <<"segments/target_group_1">>) -> CachedGroup end),
-  ?assertEqual({excluded,true}, cfclient_evaluator:is_rule_included_or_excluded(Clauses, ExcludedTarget)),
-  ?assertEqual({excluded,true}, cfclient_evaluator:is_rule_included_or_excluded(Clauses, ExcludedTargetB)),
+  ?assertEqual(excluded, cfclient_evaluator:is_rule_included_or_excluded(Clauses, ExcludedTarget)),
+  ?assertEqual(excluded, cfclient_evaluator:is_rule_included_or_excluded(Clauses, ExcludedTargetB)),
 
 
   %% Included %%
   meck:expect(lru, get, fun(CacheName, <<"segments/target_group_1">>) -> CachedGroup end),
-  ?assertEqual({included,true}, cfclient_evaluator:is_rule_included_or_excluded(Clauses, IncludedTargetA)),
-  ?assertEqual({included,true}, cfclient_evaluator:is_rule_included_or_excluded(Clauses, IncludedTargetB)),
+  ?assertEqual(included, cfclient_evaluator:is_rule_included_or_excluded(Clauses, IncludedTargetA)),
+  ?assertEqual(included, cfclient_evaluator:is_rule_included_or_excluded(Clauses, IncludedTargetB)),
 
   %% Not Included %%
   meck:expect(lru, get, fun(CacheName, <<"segments/target_group_1">>) -> CachedGroup end),
-  ?assertEqual({included,false}, cfclient_evaluator:is_rule_included_or_excluded(Clauses, NotIncludedTargetA)),
-  ?assertEqual({included,false}, cfclient_evaluator:is_rule_included_or_excluded(Clauses, NotIncludedTargetB)),
+  ?assertEqual(false, cfclient_evaluator:is_rule_included_or_excluded(Clauses, NotIncludedTargetA)),
+  ?assertEqual(false, cfclient_evaluator:is_rule_included_or_excluded(Clauses, NotIncludedTargetB)),
 
   meck:unload(lru).
 

--- a/src/cfclient_evaluator_test.erl
+++ b/src/cfclient_evaluator_test.erl
@@ -408,7 +408,22 @@ is_rule_included_or_excluded_test() ->
   meck:unload(lru).
 
 
-
+distribution_test() ->
+  #{rules =>
+  [#{clauses =>
+  [#{attribute => <<>>,
+    id => <<"e974bb15-08be-45aa-a36d-d6431ae1bfe1">>,
+    negate => false, op => <<"segmentMatch">>,
+    values => [<<"target_group_1">>]}],
+    priority => 0,
+    ruleId => <<"637019fc-6f38-4e76-9211-4da166aaa488">>,
+    serve =>
+    #{distribution =>
+    #{bucketBy => <<"identifier">>,
+      variations =>
+      [#{variation => <<"true">>, weight => 50},
+        #{variation => <<"false">>, weight => 50}]}}}]},
+  ok.
 
 boolean_flag_off() ->
   #{defaultServe => #{variation => <<"true">>},


### PR DESCRIPTION
WHAT

Previous iteration of Evaluation pipeline was hard to maintain and read. This takes a new approach utilising pattern matching instead of complex nested conditionals. 

WHY

Readability and maintainability 

TESTING

TestGrid and Unit tests pass