### PR TITLE
Percentage Rollout

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -3,6 +3,7 @@
 {deps, [
     %% git dependencies
     {cfapi, {git, "https://github.com/harness/ff-erlang-client-api", {branch, "main"}}},
+    {erlang_murmurhash, {git, "https://github.com/harness-apps/erlang-murmurhash", {branch, "master"}}},
     {lru, "2.4.0"},
     {ctx, "0.6.0"},
     {mochiweb, "3.1.1"},

--- a/src/cfclient_evaluator.erl
+++ b/src/cfclient_evaluator.erl
@@ -64,7 +64,6 @@ evaluate_flag(Flag, Target, group_rules) ->
       evaluate_flag(Flag, Target, default_on);
     GroupVariationIdentifier ->
       logger:debug("Group rule matched on Flag ~p~n with Target ~p~n", [maps:get(feature, Flag), Target]),
-      %% TODO Percentage rollout goes here - I think.
       get_target_or_group_variation(Flag, GroupVariationIdentifier)
   end;
 %% Default "on" variation
@@ -320,7 +319,6 @@ custom_attribute_list_elem_to_binary(Element) when is_list(Element) ->
 -spec apply_percentage_rollout(Variations :: list(), BucketBy :: binary(), TargetValue :: binary(), AccumulatorIn :: integer()) -> binary() | percentage_rollout_excluded.
 apply_percentage_rollout([Head | Tail], BucketBy, TargetValue, AccumulatorIn) ->
   Percentage = AccumulatorIn + maps:get(weight, Head),
-%%  Variation = maps:get(variation, Head),
   case should_rollout(BucketBy, TargetValue, Percentage) of
     true ->
       maps:get(variation, Head);
@@ -331,7 +329,6 @@ apply_percentage_rollout([], _, _, _) -> percentage_rollout_excluded.
 
 -spec should_rollout(BucketBy :: binary(), TargetValue ::binary(), integer()) -> boolean().
 should_rollout(BucketBy, TargetValue, Percentage) ->
-  %%TODO hash the joining of buketby and identifier with a ':' separator
   Hash = erlang_murmurhash:murmurhash3_32(<<TargetValue/binary,":",BucketBy/binary>>),
   BucketID = (Hash rem 100) +1,
   (Percentage > 0) andalso (BucketID =< Percentage).

--- a/src/cfclient_evaluator_test.erl
+++ b/src/cfclient_evaluator_test.erl
@@ -71,11 +71,11 @@ variations_test() ->
 
   %%-------------------- Bool Variation --------------------
   %%%%%%%% Flag is off %%%%%%%%
-  meck:expect(lru, get, fun(CacheName, <<"flags/My_boolean_flag">>) -> boolean_flag_off() end),
+  meck:expect(lru, get, fun(CacheName, <<"flags/My_boolean_flag">>) -> cfclient_evaluator_test_data:boolean_flag_off() end),
   ?assertEqual({ok,false}, cfclient_evaluator:bool_variation(<<"My_boolean_flag">>, ExistingTargetA)),
 
   %%%%%%%% Flag is on with a single target %%%%%%%%
-  meck:expect(lru, get, fun(CacheName, <<"flags/My_boolean_flag">>) -> boolean_flag_single_target() end),
+  meck:expect(lru, get, fun(CacheName, <<"flags/My_boolean_flag">>) -> cfclient_evaluator_test_data:boolean_flag_single_target() end),
   %% Target found
   ?assertEqual({ok,false}, cfclient_evaluator:bool_variation(<<"My_boolean_flag">>, ExistingTargetA)),
   %% Target not found
@@ -83,8 +83,8 @@ variations_test() ->
 
   %%%%%%%% Flag is on - no targets - but Groups %%%%%%%%
   meck:expect(lru, get, fun
-                          (CacheName, <<"segments/target_group_1">>) -> target_group();
-                          (CacheName, <<"flags/My_boolean_flag">>) -> boolean_flag_group_only()
+                          (CacheName, <<"segments/target_group_1">>) -> cfclient_evaluator_test_data:target_group();
+                          (CacheName, <<"flags/My_boolean_flag">>) -> cfclient_evaluator_test_data:boolean_flag_group_only()
                         end),
 
   %% Target excluded
@@ -106,21 +106,21 @@ variations_test() ->
   %%%%%%%% Flag is on - no targets or groups %%%%%%%%
   %% Default on variation
   meck:expect(lru, get, fun
-                          (CacheName, <<"segments/target_group_1">>) -> target_group();
-                          (CacheName, <<"flags/My_boolean_flag">>) -> boolean_flag_no_targets_or_groups()
+                          (CacheName, <<"segments/target_group_1">>) -> cfclient_evaluator_test_data:target_group();
+                          (CacheName, <<"flags/My_boolean_flag">>) -> cfclient_evaluator_test_data:boolean_flag_no_targets_or_groups()
                         end),
   ?assertEqual({ok,true}, cfclient_evaluator:bool_variation(<<"My_boolean_flag">>, TargetExcludedFromGroup)),
 
 
   %%-------------------- String Variation --------------------
   %%%%%%%% Flag is off %%%%%%%%
-  meck:expect(lru, get, fun(CacheName, <<"flags/My_string_flag">>) -> string_flag_off() end),
+  meck:expect(lru, get, fun(CacheName, <<"flags/My_string_flag">>) -> cfclient_evaluator_test_data:string_flag_off() end),
   ?assertEqual({ok,"don't serve it"}, cfclient_evaluator:string_variation(<<"My_string_flag">>, ExistingTargetA)),
 
   %%%%%%%% Flag is on with a single target %%%%%%%%
   meck:expect(lru, get, fun
-                          (CacheName, <<"segments/target_group_1">>) -> target_group();
-                          (CacheName, <<"flags/My_string_flag">>) -> string_flag_target_and_groups()
+                          (CacheName, <<"segments/target_group_1">>) -> cfclient_evaluator_test_data:target_group();
+                          (CacheName, <<"flags/My_string_flag">>) -> cfclient_evaluator_test_data:string_flag_target_and_groups()
                         end),  %% Target found
   ?assertEqual({ok, "don't serve it"}, cfclient_evaluator:string_variation(<<"My_string_flag">>, ExistingTargetA)),
   %% Target not found
@@ -144,20 +144,20 @@ variations_test() ->
   %%%%%%%% Flag is on - no targets or groups %%%%%%%%
   %% Default on variation
   meck:expect(lru, get, fun
-                          (CacheName, <<"segments/target_group_1">>) -> target_group();
-                          (CacheName, <<"flags/My_string_flag">>) -> string_flag_no_targets_or_groups()
+                          (CacheName, <<"segments/target_group_1">>) -> cfclient_evaluator_test_data:target_group();
+                          (CacheName, <<"flags/My_string_flag">>) -> cfclient_evaluator_test_data:string_flag_no_targets_or_groups()
                         end),
   ?assertEqual({ok, "serve it"}, cfclient_evaluator:string_variation(<<"My_string_flag">>, ExistingTargetA)),
 
   %%-------------------- Number Variation --------------------
   %%%%%%%% Flag is off %%%%%%%%
-  meck:expect(lru, get, fun(CacheName, <<"flags/My_cool_number_flag">>) -> number_flag_off() end),
+  meck:expect(lru, get, fun(CacheName, <<"flags/My_cool_number_flag">>) -> cfclient_evaluator_test_data:number_flag_off() end),
   ?assertEqual({ok, 0}, cfclient_evaluator:number_variation(<<"My_cool_number_flag">>, ExistingTargetA)),
 
   %%%%%%%% Flag is on with a single target %%%%%%%%
   meck:expect(lru, get, fun
-                          (CacheName, <<"segments/target_group_1">>) -> target_group();
-                          (CacheName, <<"flags/My_cool_number_flag">>) -> number_flag_only_targets()
+                          (CacheName, <<"segments/target_group_1">>) -> cfclient_evaluator_test_data:target_group();
+                          (CacheName, <<"flags/My_cool_number_flag">>) -> cfclient_evaluator_test_data:number_flag_only_targets()
                         end),
   %% Target found
   ?assertEqual({ok, 0}, cfclient_evaluator:number_variation(<<"My_cool_number_flag">>, ExistingTargetA)),
@@ -166,8 +166,8 @@ variations_test() ->
 
   %%%%%% Flag is on - no targets - but Groups %%%%%%%%
   meck:expect(lru, get, fun
-                          (CacheName, <<"segments/target_group_1">>) -> target_group();
-                          (CacheName, <<"flags/My_cool_number_flag">>) -> number_flag_only_groups()
+                          (CacheName, <<"segments/target_group_1">>) -> cfclient_evaluator_test_data:target_group();
+                          (CacheName, <<"flags/My_cool_number_flag">>) -> cfclient_evaluator_test_data:number_flag_only_groups()
                         end),
   %% Target excluded
   ?assertEqual({ok, 12456}, cfclient_evaluator:number_variation(<<"My_cool_number_flag">>, TargetExcludedFromGroup)),
@@ -185,20 +185,20 @@ variations_test() ->
   %%%%%%%% Flag is on - no targets or groups %%%%%%%%
   %% Default on variation
   meck:expect(lru, get, fun
-                          (CacheName, <<"segments/target_group_1">>) -> target_group();
-                          (CacheName, <<"flags/My_cool_number_flag">>) -> number_flag_no_targets_or_groups()
+                          (CacheName, <<"segments/target_group_1">>) -> cfclient_evaluator_test_data:target_group();
+                          (CacheName, <<"flags/My_cool_number_flag">>) -> cfclient_evaluator_test_data:number_flag_no_targets_or_groups()
                         end),
   ?assertEqual({ok, 12456}, cfclient_evaluator:number_variation(<<"My_cool_number_flag">>, ExistingTargetA)),
 
   %%-------------------- JSON Variation --------------------
   %%%%%%%% Flag is off %%%%%%%%
-  meck:expect(lru, get, fun(CacheName, <<"flags/My_JSON_flag">>) -> json_flag_off() end),
+  meck:expect(lru, get, fun(CacheName, <<"flags/My_JSON_flag">>) -> cfclient_evaluator_test_data:json_flag_off() end),
   ?assertEqual({ok, #{<<"serveIt">> => <<"no">>}}, cfclient_evaluator:json_variation(<<"My_JSON_flag">>, ExistingTargetA)),
 
   %%%%%%%% Flag is on with a single target %%%%%%%%
   meck:expect(lru, get, fun
-                          (CacheName, <<"segments/target_group_1">>) -> target_group();
-                          (CacheName, <<"flags/My_JSON_flag">>) -> json_flag_only_targets()
+                          (CacheName, <<"segments/target_group_1">>) -> cfclient_evaluator_test_data:target_group();
+                          (CacheName, <<"flags/My_JSON_flag">>) -> cfclient_evaluator_test_data:json_flag_only_targets()
                         end),
   %% Target found
   ?assertEqual({ok, #{<<"serveIt">> => <<"no">>}}, cfclient_evaluator:json_variation(<<"My_JSON_flag">>, ExistingTargetA)),
@@ -207,8 +207,8 @@ variations_test() ->
 
   %%%%%% Flag is on - no targets - but Groups %%%%%%%%
   meck:expect(lru, get, fun
-                          (CacheName, <<"segments/target_group_1">>) -> target_group();
-                          (CacheName, <<"flags/My_JSON_flag">>) -> json_flag_only_groups()
+                          (CacheName, <<"segments/target_group_1">>) -> cfclient_evaluator_test_data:target_group();
+                          (CacheName, <<"flags/My_JSON_flag">>) -> cfclient_evaluator_test_data:json_flag_only_groups()
                         end),
   %% Target excluded
   ?assertEqual({ok, #{<<"serveIt">> => <<"yes">>}}, cfclient_evaluator:json_variation(<<"My_JSON_flag">>, TargetExcludedFromGroup)),
@@ -226,8 +226,8 @@ variations_test() ->
   %%%%%%%% Flag is on - no targets or groups %%%%%%%%
   %% Default on variation
   meck:expect(lru, get, fun
-                          (CacheName, <<"segments/target_group_1">>) -> target_group();
-                          (CacheName, <<"flags/My_JSON_flag">>) -> json_flag_no_targets_or_groups()
+                          (CacheName, <<"segments/target_group_1">>) -> cfclient_evaluator_test_data:target_group();
+                          (CacheName, <<"flags/My_JSON_flag">>) -> cfclient_evaluator_test_data:json_flag_no_targets_or_groups()
                         end),
   ?assertEqual({ok, #{<<"serveIt">> => <<"yes">>}}, cfclient_evaluator:json_variation(<<"My_JSON_flag">>, ExistingTargetA)),
 
@@ -743,508 +743,34 @@ custom_attribute_to_binary_test() ->
   ?assertEqual([not_ok, not_ok], cfclient_evaluator:custom_attribute_to_binary(ListStrings)).
 
 percentage_rollout_test() ->
-  #{rules =>
-  [#{clauses =>
-  [#{attribute => <<>>,
-    id => <<"e974bb15-08be-45aa-a36d-d6431ae1bfe1">>,
-    negate => false, op => <<"segmentMatch">>,
-    values => [<<"target_group_1">>]}],
-    priority => 0,
-    ruleId => <<"637019fc-6f38-4e76-9211-4da166aaa488">>,
-    serve =>
-    #{distribution =>
-    #{bucketBy => <<"identifier">>,
-      variations =>
-      [#{variation => <<"true">>, weight => 50},
-        #{variation => <<"false">>, weight => 50}]}}}]},
+  cfclient_cache_repository:set_pid(self()),
+  meck:expect(lru, get, fun
+                          (CacheName, <<"segments/target_group_1">>) -> cfclient_evaluator_test_data:target_group_for_percentage_rollout();
+                          (CacheName, <<"flags/My_boolean_flag">>) -> cfclient_evaluator_test_data:percentage_rollout_boolean_50_50()
+                        end),
 
-  #{defaultServe =>
-  #{variation =>
-  <<"true">>},
-    environment => <<"dev">>,
-    feature => <<"test">>,
-    kind => <<"boolean">>,
-    offVariation => <<"false">>,
-    prerequisites => [],
-    project =>
-    <<"erlangcustomrules">>,
-    rules =>
-    [#{clauses =>
-    [#{attribute =>
-    <<>>,
-      id =>
-      <<"3cd6a8c7-79d6-4697-b007-b8486f0568ba">>,
-      negate =>
-      false,
-      op =>
-      <<"segmentMatch">>,
-      values =>
-      [<<"group1">>]}],
-      priority => 0,
-      ruleId =>
-      <<"12410622-e1d1-46c9-acb3-e177c9dd4575">>,
-      serve =>
-      #{distribution =>
-      #{bucketBy =>
-      <<"identifier">>,
-        variations =>
-        [#{variation =>
-        <<"true">>,
-          weight =>
-          10},
-          #{variation =>
-          <<"false">>,
-            weight =>
-            90}]}}}],
-    state => <<"on">>,
-    variationToTargetMap =>
-    null,
-    variations =>
-    [#{identifier =>
-    <<"true">>,
-      name => <<"True">>,
-      value => <<"true">>},
-      #{identifier =>
-      <<"false">>,
-        name => <<"False">>,
-        value =>
-        <<"false">>}],
-    version => 4},
-  ok.
+  DoVariation50Times =
+    fun
+      F({TrueCounter, FalseCounter}, 50) -> {TrueCounter, FalseCounter};
+        F({TrueCounter, FalseCounter}, AccuIn) ->
+        Counter = AccuIn + 1,
+        TargetIdentifierNumber = integer_to_binary(Counter),
+        DynamicTarget = #{'identifier' => <<"target",TargetIdentifierNumber/binary>>,
+          name => <<"targetname",TargetIdentifierNumber/binary>>,
+          anonymous => <<"">>
+        },
+        case cfclient_evaluator:bool_variation(<<"My_boolean_flag">>, DynamicTarget) of
+          {ok,true} ->
+            F({TrueCounter + 1, FalseCounter + 0}, Counter);
+          {ok,false} ->
+            F({TrueCounter + 0, FalseCounter + 1}, Counter)
+        end
+    end,
+  DoVariation50Times({0, 0}, 0),
 
-boolean_flag_off() ->
-  #{defaultServe => #{variation => <<"true">>},
-    environment => <<"dev">>, feature => <<"My_boolean_flag">>,
-    kind => <<"boolean">>, offVariation => <<"false">>,
-    prerequisites => [], project => <<"erlangsdktest">>,
-    rules =>
-    [#{clauses =>
-    [#{attribute => <<>>,
-      id => <<"d20dbdea-2b38-4343-b6fc-6fb09d41674d">>,
-      negate => false, op => <<"segmentMatch">>,
-      values => [<<"target_group_1">>]}],
-      priority => 0,
-      ruleId => <<"fbd0df98-2867-496d-8443-e3578236623d">>,
-      serve => #{variation => <<"true">>}}],
-    state => <<"off">>,
-    variationToTargetMap =>
-    [#{targets =>
-    [#{identifier => <<"target_identifier">>,
-      name => <<"target_test">>}],
-      variation => <<"true">>}],
-    variations =>
-    [#{identifier => <<"true">>, name => <<"True">>,
-      value => <<"true">>},
-      #{identifier => <<"false">>, name => <<"False">>,
-        value => <<"false">>}],
-    version => 4}.
+%%  ?assertEqual({ok,false}, cfclient_evaluator:bool_variation(<<"My_boolean_flag">>, TargetIncludedFromGroup)),
 
-boolean_flag_no_targets_or_groups() ->
-  #{defaultServe => #{variation => <<"true">>},
-    environment => <<"dev">>, feature => <<"My_boolean_flag">>,
-    kind => <<"boolean">>, offVariation => <<"false">>,
-    prerequisites => [], project => <<"erlangsdktest">>,
-    rules => [],
-    state => <<"on">>,
-    variationToTargetMap => null,
-    variations =>
-    [#{identifier => <<"true">>, name => <<"True">>,
-      value => <<"true">>},
-      #{identifier => <<"false">>, name => <<"False">>,
-        value => <<"false">>}],
-    version => 4}.
-
-boolean_flag_group_only() ->
-  #{defaultServe => #{variation => <<"true">>},
-    environment => <<"dev">>, feature => <<"My_boolean_flag">>,
-    kind => <<"boolean">>, offVariation => <<"false">>,
-    prerequisites => [], project => <<"erlangsdktest">>,
-    rules =>
-    [#{clauses =>
-    [#{attribute => <<>>,
-      id => <<"d20dbdea-2b38-4343-b6fc-6fb09d41674d">>,
-      negate => false, op => <<"segmentMatch">>,
-      values => [<<"target_group_1">>]}],
-      priority => 0,
-      ruleId => <<"fbd0df98-2867-496d-8443-e3578236623d">>,
-      serve => #{variation => <<"false">>}}],
-    state => <<"on">>,
-    variationToTargetMap => null,
-    variations =>
-    [#{identifier => <<"true">>, name => <<"True">>,
-      value => <<"true">>},
-      #{identifier => <<"false">>, name => <<"False">>,
-        value => <<"false">>}],
-    version => 4}.
-
-boolean_flag_single_target() ->
-  #{defaultServe => #{variation => <<"true">>},
-    environment => <<"dev">>, feature => <<"My_boolean_flag">>,
-    kind => <<"boolean">>, offVariation => <<"false">>,
-    prerequisites => [], project => <<"erlangsdktest">>,
-    rules => [],
-    state => <<"on">>,
-    variationToTargetMap =>
-    [#{targets =>
-    [#{identifier => <<"target_identifier_2">>, name => <<"target_2">>},
-      #{identifier => <<"target_identifier_1">>, name => <<"target_1">>}],
-      variation => <<"false">>}],
-    variations =>
-    [#{identifier => <<"true">>, name => <<"True">>,
-      value => <<"true">>},
-      #{identifier => <<"false">>, name => <<"False">>,
-        value => <<"false">>}],
-    version => 4}.
-
-string_flag_off() ->
-  #{defaultServe => #{variation => <<"Serve_it">>},
-    environment => <<"dev">>, feature => <<"My_string_flag">>,
-    kind => <<"string">>, offVariation => <<"Dont_serve_it">>,
-    prerequisites => [], project => <<"erlangsdktest">>,
-    rules =>
-    [#{clauses =>
-    [#{attribute => <<>>,
-      id => <<"1e80543a-c78a-4543-94fa-8277ba8507c1">>,
-      negate => false, op => <<"segmentMatch">>,
-      values => [<<"target_group_2">>]}],
-      priority => 0,
-      ruleId => <<"2f81fac2-cb53-492c-b1e4-1d0766008a21">>,
-      serve => #{variation => <<"Dont_serve_it">>}}],
-    state => <<"off">>,
-    variationToTargetMap =>
-    [#{targets =>
-    [#{identifier => <<"target_test_1">>,
-      name => <<"target_test_1">>}],
-      variation => <<"Serve_it">>}],
-    variations =>
-    [#{identifier => <<"Serve_it">>, name => <<"Serve it">>,
-      value => <<"serve it">>},
-      #{identifier => <<"Dont_serve_it">>,
-        name => <<"Don't serve it ">>,
-        value => <<"don't serve it">>}],
-    version => 2}.
-
-string_flag_no_targets_or_groups() ->
-  #{defaultServe => #{variation => <<"Serve_it">>},
-    environment => <<"dev">>, feature => <<"My_string_flag">>,
-    kind => <<"string">>, offVariation => <<"Dont_serve_it">>,
-    prerequisites => [], project => <<"erlangsdktest">>,
-    rules => [], state => <<"on">>, variationToTargetMap => null,
-    variations =>
-    [#{identifier => <<"Serve_it">>, name => <<"Serve it">>,
-      value => <<"serve it">>},
-      #{identifier => <<"Dont_serve_it">>,
-        name => <<"Don't serve it ">>,
-        value => <<"don't serve it">>}],
-    version => 2}.
-
-string_flag_target_and_groups() ->
-  #{defaultServe => #{variation => <<"Serve_it">>},
-    environment => <<"dev">>, feature => <<"My_string_flag">>,
-    kind => <<"string">>, offVariation => <<"Dont_serve_it">>,
-    prerequisites => [], project => <<"erlangsdktest">>,
-    rules =>
-    [#{clauses =>
-    [#{attribute => <<>>,
-      id => <<"1e80543a-c78a-4543-94fa-8277ba8507c1">>,
-      negate => false, op => <<"segmentMatch">>,
-      values => [<<"target_group_1">>]}],
-      priority => 0,
-      ruleId => <<"2f81fac2-cb53-492c-b1e4-1d0766008a21">>,
-      serve => #{variation => <<"Dont_serve_it">>}}],
-    state => <<"on">>,
-    variationToTargetMap =>
-    [#{targets =>
-    [#{identifier => <<"target_identifier_1">>,
-      name => <<"target_test_1">>}],
-      variation => <<"Dont_serve_it">>}],
-    variations =>
-    [#{identifier => <<"Serve_it">>, name => <<"Serve it">>,
-      value => <<"serve it">>},
-      #{identifier => <<"Dont_serve_it">>,
-        name => <<"Don't serve it ">>,
-        value => <<"don't serve it">>}],
-    version => 2}.
-
-number_flag_off() ->
-  #{defaultServe => #{variation => <<"Serve_an_int">>},
-    environment => <<"dev">>,
-    feature => <<"My_cool_number_flag">>, kind => <<"int">>,
-    offVariation => <<"Serve_a_zero_int">>, prerequisites => [],
-    project => <<"erlangsdktest">>,
-    rules =>
-    [#{clauses =>
-    [#{attribute => <<>>,
-      id => <<"a6818821-eaab-467c-ae1c-823b9798619d">>,
-      negate => false, op => <<"segmentMatch">>,
-      values => [<<"target_group_2">>]}],
-      priority => 0,
-      ruleId => <<"cf5cc01a-e2dc-442b-9d86-f4db6ac2a180">>,
-      serve => #{variation => <<"Serve_a_zero_float">>}},
-      #{clauses =>
-      [#{attribute => <<>>,
-        id => <<"8f2e5f62-0ee0-43e6-8a64-3a40fe72f9f2">>,
-        negate => false, op => <<"segmentMatch">>,
-        values => [<<"target_group_1">>]}],
-        priority => 1,
-        ruleId => <<"be265486-b7d8-4382-a27a-6a9b929de365">>,
-        serve => #{variation => <<"Serve_a_float">>}}],
-    state => <<"off">>,
-    variationToTargetMap =>
-    [#{targets =>
-    [#{identifier => <<"target_identifier_3434">>,
-      name => <<"target_test">>},
-      #{identifier => <<"target_test_1">>,
-        name => <<"target_test_3">>}],
-      variation => <<"Serve_an_int">>}],
-    variations =>
-    [#{identifier => <<"Serve_an_int">>, name => <<"Serve an int">>,
-      value => <<"12456">>},
-      #{identifier => <<"Serve_a_zero_int">>,
-        name => <<"Serve a zero int">>, value => <<"0">>},
-      #{identifier => <<"Serve_a_float">>,
-        name => <<"Serve a float">>, value => <<"1.55">>},
-      #{identifier => <<"Serve_a_zero_float">>,
-        name => <<"Serve a zero float">>, value => <<"0.001">>}],
-    version => 3}.
-
-number_flag_only_targets() ->
-  #{defaultServe => #{variation => <<"Serve_an_int">>},
-    environment => <<"dev">>,
-    feature => <<"My_cool_number_flag">>, kind => <<"int">>,
-    offVariation => <<"Serve_a_zero_int">>, prerequisites => [],
-    project => <<"erlangsdktest">>,
-    rules => [],
-    state => <<"on">>,
-    variationToTargetMap =>
-    [#{targets =>
-    [#{identifier => <<"target_identifier_3434">>,
-      name => <<"target_test">>},
-      #{identifier => <<"target_identifier_1">>,
-        name => <<"target_test_3">>}],
-      variation => <<"Serve_a_zero_int">>}],
-    variations =>
-    [#{identifier => <<"Serve_an_int">>, name => <<"Serve an int">>,
-      value => <<"12456">>},
-      #{identifier => <<"Serve_a_zero_int">>,
-        name => <<"Serve a zero int">>, value => <<"0">>},
-      #{identifier => <<"Serve_a_float">>,
-        name => <<"Serve a float">>, value => <<"1.55">>},
-      #{identifier => <<"Serve_a_zero_float">>,
-        name => <<"Serve a zero float">>, value => <<"0.001">>}],
-    version => 3}.
+  asd.
 
 
-number_flag_no_targets_or_groups() ->
-  #{defaultServe => #{variation => <<"Serve_an_int">>},
-    environment => <<"dev">>,
-    feature => <<"My_cool_number_flag">>, kind => <<"int">>,
-    offVariation => <<"Serve_a_zero_int">>, prerequisites => [],
-    project => <<"erlangsdktest">>,
-    rules => [],
-    state => <<"on">>,
-    variationToTargetMap => null,
-    variations =>
-    [#{identifier => <<"Serve_an_int">>, name => <<"Serve an int">>,
-      value => <<"12456">>},
-      #{identifier => <<"Serve_a_zero_int">>,
-        name => <<"Serve a zero int">>, value => <<"0">>},
-      #{identifier => <<"Serve_a_float">>,
-        name => <<"Serve a float">>, value => <<"1.55">>},
-      #{identifier => <<"Serve_a_zero_float">>,
-        name => <<"Serve a zero float">>, value => <<"0.001">>}],
-    version => 3}.
 
-number_flag_only_groups() ->
-  #{defaultServe => #{variation => <<"Serve_an_int">>},
-    environment => <<"dev">>,
-    feature => <<"My_cool_number_flag">>, kind => <<"int">>,
-    offVariation => <<"Serve_a_zero_int">>, prerequisites => [],
-    project => <<"erlangsdktest">>,
-    rules =>
-    [#{clauses =>
-    [#{attribute => <<>>,
-      id => <<"a6818821-eaab-467c-ae1c-823b9798619d">>,
-      negate => false, op => <<"segmentMatch">>,
-      values => [<<"target_group_1">>]}],
-      priority => 0,
-      ruleId => <<"cf5cc01a-e2dc-442b-9d86-f4db6ac2a180">>,
-      serve => #{variation => <<"Serve_a_zero_float">>}},
-      #{clauses =>
-      [#{attribute => <<>>,
-        id => <<"8f2e5f62-0ee0-43e6-8a64-3a40fe72f9f2">>,
-        negate => false, op => <<"segmentMatch">>,
-        values => [<<"target_group_1">>]}],
-        priority => 1,
-        ruleId => <<"be265486-b7d8-4382-a27a-6a9b929de365">>,
-        serve => #{variation => <<"Serve_a_float">>}}],
-    state => <<"on">>,
-    variationToTargetMap => null,
-    variations =>
-    [#{identifier => <<"Serve_an_int">>, name => <<"Serve an int">>,
-      value => <<"12456">>},
-      #{identifier => <<"Serve_a_zero_int">>,
-        name => <<"Serve a zero int">>, value => <<"0">>},
-      #{identifier => <<"Serve_a_float">>,
-        name => <<"Serve a float">>, value => <<"1.55">>},
-      #{identifier => <<"Serve_a_zero_float">>,
-        name => <<"Serve a zero float">>, value => <<"0.001">>}],
-    version => 3}.
-
-json_flag_off() ->
-  #{defaultServe => #{variation => <<"Serve_it">>},
-    environment => <<"dev">>,feature => <<"My_JSON_flag">>,
-    kind => <<"json">>,offVariation => <<"Dont_serve_it">>,
-    prerequisites => [],project => <<"erlangsdktest">>,
-    rules =>
-    [#{clauses =>
-    [#{attribute => <<>>,
-      id => <<"011331a7-2ea8-4db3-91f7-68729a566e86">>,
-      negate => false,op => <<"segmentMatch">>,
-      values => [<<"target_group_1">>]}],
-      priority => 0,
-      ruleId => <<"3f8be42e-c6b5-43ff-9d24-51d0e0027117">>,
-      serve => #{variation => <<"Dont_serve_it">>}}],
-    state => <<"off">>,variationToTargetMap => null,
-    variations =>
-    [#{identifier => <<"Serve_it">>,name => <<"Serve it">>,
-      value => <<"{    \"serveIt\":\"yes\" }">>},
-      #{identifier => <<"Dont_serve_it">>,
-        name => <<"Don't serve it">>,
-        value => <<"{    \"serveIt\":\"no\" }">>}],
-    version => 3}.
-
-json_flag_only_targets() ->
-  #{defaultServe => #{variation => <<"Serve_it">>},
-    environment => <<"dev">>,feature => <<"My_JSON_flag">>,
-    kind => <<"json">>,offVariation => <<"Dont_serve_it">>,
-    prerequisites => [],project => <<"erlangsdktest">>,
-    rules => [],state => <<"on">>,
-    variationToTargetMap =>
-    [#{targets =>
-    [#{identifier => <<"target_identifier_1">>,
-      name => <<"target_test_1">>},
-      #{identifier => <<"target_test_2">>,
-        name => <<"target_test_2">>}],
-      variation => <<"Dont_serve_it">>}],
-    variations =>
-    [#{identifier => <<"Serve_it">>,name => <<"Serve it">>,
-      value => <<"{    \"serveIt\":\"yes\" }">>},
-      #{identifier => <<"Dont_serve_it">>,
-        name => <<"Don't serve it">>,
-        value => <<"{    \"serveIt\":\"no\" }">>}],
-    version => 4}.
-
-json_flag_no_targets_or_groups() ->
-  #{defaultServe => #{variation => <<"Serve_it">>},
-    environment => <<"dev">>,feature => <<"My_JSON_flag">>,
-    kind => <<"json">>,offVariation => <<"Dont_serve_it">>,
-    prerequisites => [],project => <<"erlangsdktest">>,
-    rules => [],state => <<"on">>,
-    variationToTargetMap => null,
-    variations =>
-    [#{identifier => <<"Serve_it">>,name => <<"Serve it">>,
-      value => <<"{    \"serveIt\":\"yes\" }">>},
-      #{identifier => <<"Dont_serve_it">>,
-        name => <<"Don't serve it">>,
-        value => <<"{    \"serveIt\":\"no\" }">>}],
-    version => 4}.
-
-json_flag_only_groups() ->
-  #{defaultServe => #{variation => <<"Serve_it">>},
-    environment => <<"dev">>,feature => <<"My_JSON_flag">>,
-    kind => <<"json">>,offVariation => <<"Dont_serve_it">>,
-    prerequisites => [],project => <<"erlangsdktest">>,
-    rules =>
-    [#{clauses =>
-    [#{attribute => <<>>,
-      id => <<"bdaf96d2-1a65-44c3-b367-f0eb610e6e39">>,
-      negate => false,op => <<"segmentMatch">>,
-      values => [<<"target_group_1">>]}],
-      priority => 5,
-      ruleId => <<"1676d97b-59e9-44c3-9806-748206d85978">>,
-      serve => #{variation => <<"Maybe_serve_it">>}}]
-    ,state => <<"on">>,
-    variationToTargetMap => null,
-    variations =>
-    [#{identifier => <<"Serve_it">>,name => <<"Serve it">>,
-      value => <<"{    \"serveIt\":\"yes\" }">>},
-      #{identifier => <<"Dont_serve_it">>,
-        name => <<"Don't serve it">>,
-        value => <<"{    \"serveIt\":\"no\" }">>},
-      #{identifier => <<"Maybe_serve_it">>,
-        name => <<"Maybe serve it">>,
-        value => <<"{    \"serveIt\":\"maybe\" }">>}],
-    version => 4}.
-
-json_flag_targets_and_groups() ->
-  #{defaultServe => #{variation => <<"Serve_it">>},
-    environment => <<"dev">>,feature => <<"My_JSON_flag">>,
-    kind => <<"json">>,offVariation => <<"Dont_serve_it">>,
-    prerequisites => [],project => <<"erlangsdktest">>,
-    rules =>
-    [#{clauses =>
-    [#{attribute => <<>>,
-      id => <<"bdaf96d2-1a65-44c3-b367-f0eb610e6e39">>,
-      negate => false,op => <<"segmentMatch">>,
-      values => [<<"target_group_1">>]}],
-      priority => 5,
-      ruleId => <<"1676d97b-59e9-44c3-9806-748206d85978">>,
-      serve => #{variation => <<"Maybe_serve_it">>}}],
-    state => <<"on">>,
-    variationToTargetMap =>
-    [#{targets =>
-    [#{identifier => <<"target_identifier_1">>,
-      name => <<"target_test">>},
-      #{identifier => <<"target_test_2">>,
-        name => <<"target_test_2">>}],
-      variation => <<"Dont_serve_it">>}],
-    variations =>
-    [#{identifier => <<"Serve_it">>,name => <<"Serve it">>,
-      value => <<"{    \"serveIt\":\"yes\" }">>},
-      #{identifier => <<"Dont_serve_it">>,
-        name => <<"Don't serve it">>,
-        value => <<"{    \"serveIt\":\"no\" }">>},
-      #{description => <<>>,identifier => <<"Maybe_serve_it">>,
-        name => <<"Maybe serve it">>,
-        value => <<"{    \"serveIt\":\"maybe\" }">>}],
-    version => 8}.
-
-target_group() ->
-  #{environment => <<"dev">>,
-    excluded =>
-    [#{account => <<>>, environment => <<>>,
-      identifier => <<"target_that_has_been_excluded">>,
-      name => <<"target_test_2">>, org => <<>>, project => <<>>}],
-    identifier => <<"target_group_1">>,
-    included =>
-    [#{account => <<>>, environment => <<>>,
-      identifier => <<"target_that_has_been_inlcuded">>,
-      name => <<"target_test">>, org => <<>>, project => <<>>}],
-    name => <<"target_group_1">>,
-    rules =>
-    [#{attribute => <<"location">>,
-      id => <<"493945ee-b37b-466d-900e-846a24c93bec">>,
-      negate => false,op => <<"ends_with">>,
-      values => [<<"1">>]},
-      #{attribute => <<"identifier">>,
-        id => <<"7f779368-036c-40e3-a8b7-8b69bd809f39">>,
-        negate => false,op => <<"ends_with">>,
-        values => [<<"2">>]},
-      #{attribute => <<"ab_testing">>,
-        id => <<"06bcb37b-111b-41c2-805a-d232e5e3dd11">>,
-        negate => false,op => <<"starts_with">>,
-        values => [<<"focus_group">>]},
-      #{attribute => <<"ab_testing">>,
-        id => <<"06bcb37b-111b-41c2-805a-d232e5e3dd11">>,
-        negate => false,op => <<"equal">>,
-        values => [<<"new_users">>]},
-      #{attribute => <<"ab_testing">>,
-        id => <<"06bcb37b-111b-41c2-805a-d232e5e3dd11">>,
-        negate => false,op => <<"equal_sensitive">>,
-        values => [<<"GREAT_GROUP">>]},
-      #{attribute => <<"beta">>,
-        id => <<"06bcb37b-111b-41c2-805a-d232e5e3dd11">>,
-        negate => false,op => <<"in">>,
-        values => [<<"target_999">>, <<"target_1000">>]}],
-    version => 19}.

--- a/src/cfclient_evaluator_test.erl
+++ b/src/cfclient_evaluator_test.erl
@@ -749,9 +749,9 @@ percentage_rollout_test() ->
                           (CacheName, <<"flags/My_boolean_flag">>) -> cfclient_evaluator_test_data:percentage_rollout_boolean_50_50()
                         end),
 
-  DoVariation50Times =
+  DoVariation10Times =
     fun
-      F({TrueCounter, FalseCounter}, 50) -> {TrueCounter, FalseCounter};
+      F({TrueCounter, FalseCounter}, 20) -> {TrueCounter, FalseCounter};
         F({TrueCounter, FalseCounter}, AccuIn) ->
         Counter = AccuIn + 1,
         TargetIdentifierNumber = integer_to_binary(Counter),
@@ -766,11 +766,12 @@ percentage_rollout_test() ->
             F({TrueCounter + 0, FalseCounter + 1}, Counter)
         end
     end,
-  DoVariation50Times({0, 0}, 0),
+  ?assertEqual({12, 8}, DoVariation10Times({0, 0}, 0)).
 
-%%  ?assertEqual({ok,false}, cfclient_evaluator:bool_variation(<<"My_boolean_flag">>, TargetIncludedFromGroup)),
-
-  asd.
+%%  logger:error("True Counter: ~p~n \n False Counter ~p~n: ", [TrueCounter, FalseCounter]),
+%%%%  ?assertEqual({ok,false}, cfclient_evaluator:bool_variation(<<"My_boolean_flag">>, TargetIncludedFromGroup)),
+%%
+%%  asd.
 
 
 

--- a/src/cfclient_evaluator_test.erl
+++ b/src/cfclient_evaluator_test.erl
@@ -742,7 +742,7 @@ custom_attribute_to_binary_test() ->
   ListStrings = ["Sample 1", "Sample2"],
   ?assertEqual([not_ok, not_ok], cfclient_evaluator:custom_attribute_to_binary(ListStrings)).
 
-distribution_test() ->
+percentage_rollout_test() ->
   #{rules =>
   [#{clauses =>
   [#{attribute => <<>>,
@@ -757,6 +757,59 @@ distribution_test() ->
       variations =>
       [#{variation => <<"true">>, weight => 50},
         #{variation => <<"false">>, weight => 50}]}}}]},
+
+  #{defaultServe =>
+  #{variation =>
+  <<"true">>},
+    environment => <<"dev">>,
+    feature => <<"test">>,
+    kind => <<"boolean">>,
+    offVariation => <<"false">>,
+    prerequisites => [],
+    project =>
+    <<"erlangcustomrules">>,
+    rules =>
+    [#{clauses =>
+    [#{attribute =>
+    <<>>,
+      id =>
+      <<"3cd6a8c7-79d6-4697-b007-b8486f0568ba">>,
+      negate =>
+      false,
+      op =>
+      <<"segmentMatch">>,
+      values =>
+      [<<"group1">>]}],
+      priority => 0,
+      ruleId =>
+      <<"12410622-e1d1-46c9-acb3-e177c9dd4575">>,
+      serve =>
+      #{distribution =>
+      #{bucketBy =>
+      <<"identifier">>,
+        variations =>
+        [#{variation =>
+        <<"true">>,
+          weight =>
+          10},
+          #{variation =>
+          <<"false">>,
+            weight =>
+            90}]}}}],
+    state => <<"on">>,
+    variationToTargetMap =>
+    null,
+    variations =>
+    [#{identifier =>
+    <<"true">>,
+      name => <<"True">>,
+      value => <<"true">>},
+      #{identifier =>
+      <<"false">>,
+        name => <<"False">>,
+        value =>
+        <<"false">>}],
+    version => 4},
   ok.
 
 boolean_flag_off() ->

--- a/src/cfclient_evaluator_test.erl
+++ b/src/cfclient_evaluator_test.erl
@@ -751,7 +751,7 @@ percentage_rollout_test() ->
                         end),
 
   %% For low target counts, in this case 20, a split like this is expected.
-  ?assertEqual({12, 8}, do_variation_10_times({0, 0}, 0)),
+  ?assertEqual({12, 8}, do_variation_20_times({0, 0}, 0)),
 
   %%-------------------- 100/0 ------------------------------------------------------------
   cfclient_cache_repository:set_pid(self()),
@@ -759,7 +759,7 @@ percentage_rollout_test() ->
                           (CacheName, <<"segments/target_group_1">>) -> cfclient_evaluator_test_data:target_group_for_percentage_rollout();
                           (CacheName, <<"flags/My_boolean_flag">>) -> cfclient_evaluator_test_data:percentage_rollout_boolean_100_true()
                         end),
-  ?assertEqual({20,0}, do_variation_10_times({0, 0}, 0)),
+  ?assertEqual({20,0}, do_variation_20_times({0, 0}, 0)),
 
 %%-------------------- 0/100 ------------------------------------------------------------
   cfclient_cache_repository:set_pid(self()),
@@ -767,11 +767,11 @@ percentage_rollout_test() ->
                           (CacheName, <<"segments/target_group_1">>) -> cfclient_evaluator_test_data:target_group_for_percentage_rollout();
                           (CacheName, <<"flags/My_boolean_flag">>) -> cfclient_evaluator_test_data:percentage_rollout_boolean_100_false()
                         end),
-  ?assertEqual({0,20}, do_variation_10_times({0, 0}, 0)).
+  ?assertEqual({0,20}, do_variation_20_times({0, 0}, 0)).
 
 
-do_variation_10_times({TrueCounter, FalseCounter}, 20) -> {TrueCounter, FalseCounter};
-do_variation_10_times({TrueCounter, FalseCounter}, AccuIn) ->
+do_variation_20_times({TrueCounter, FalseCounter}, 20) -> {TrueCounter, FalseCounter};
+do_variation_20_times({TrueCounter, FalseCounter}, AccuIn) ->
   Counter = AccuIn + 1,
   TargetIdentifierNumber = integer_to_binary(Counter),
   DynamicTarget = #{'identifier' => <<"target",TargetIdentifierNumber/binary>>,
@@ -780,17 +780,9 @@ do_variation_10_times({TrueCounter, FalseCounter}, AccuIn) ->
   },
   case cfclient_evaluator:bool_variation(<<"My_boolean_flag">>, DynamicTarget) of
     {ok,true} ->
-      do_variation_10_times({TrueCounter + 1, FalseCounter + 0}, Counter);
+      do_variation_20_times({TrueCounter + 1, FalseCounter + 0}, Counter);
     {ok,false} ->
-      do_variation_10_times({TrueCounter + 0, FalseCounter + 1}, Counter)
+      do_variation_20_times({TrueCounter + 0, FalseCounter + 1}, Counter)
   end.
-
-
-
-%%  logger:error("True Counter: ~p~n \n False Counter ~p~n: ", [TrueCounter, FalseCounter]),
-%%%%  ?assertEqual({ok,false}, cfclient_evaluator:bool_variation(<<"My_boolean_flag">>, TargetIncludedFromGroup)),
-%%
-%%  asd.
-
 
 

--- a/src/cfclient_evaluator_test.erl
+++ b/src/cfclient_evaluator_test.erl
@@ -743,6 +743,7 @@ custom_attribute_to_binary_test() ->
   ?assertEqual([not_ok, not_ok], cfclient_evaluator:custom_attribute_to_binary(ListStrings)).
 
 percentage_rollout_test() ->
+  %%-------------------- 50/50 --------------------
   cfclient_cache_repository:set_pid(self()),
   meck:expect(lru, get, fun
                           (CacheName, <<"segments/target_group_1">>) -> cfclient_evaluator_test_data:target_group_for_percentage_rollout();
@@ -766,7 +767,52 @@ percentage_rollout_test() ->
             F({TrueCounter + 0, FalseCounter + 1}, Counter)
         end
     end,
-  ?assertEqual({12, 8}, DoVariation10Times({0, 0}, 0)).
+  %% For low target counts, in this case 20, a split like this is expected.
+  ?assertEqual({12, 8}, DoVariation10Times({0, 0}, 0)),
+
+  %%-------------------- 100/0 True --------------------
+  cfclient_cache_repository:set_pid(self()),
+  meck:expect(lru, get, fun
+                          (CacheName, <<"segments/target_group_1">>) -> cfclient_evaluator_test_data:target_group_for_percentage_rollout();
+                          (CacheName, <<"flags/My_boolean_flag">>) -> cfclient_evaluator_test_data:percentage_rollout_boolean_100_true()
+                        end),
+
+  DoVariation10Times =
+    fun
+      F({TrueCounter, FalseCounter}, 20) -> {TrueCounter, FalseCounter};
+      F({TrueCounter, FalseCounter}, AccuIn) ->
+        Counter = AccuIn + 1,
+        TargetIdentifierNumber = integer_to_binary(Counter),
+        DynamicTarget = #{'identifier' => <<"target",TargetIdentifierNumber/binary>>,
+          name => <<"targetname",TargetIdentifierNumber/binary>>,
+          anonymous => <<"">>
+        },
+        case cfclient_evaluator:bool_variation(<<"My_boolean_flag">>, DynamicTarget) of
+          {ok,true} ->
+            F({TrueCounter + 1, FalseCounter + 0}, Counter);
+          {ok,false} ->
+            F({TrueCounter + 0, FalseCounter + 1}, Counter)
+        end
+    end,
+  ?assertEqual({100,0}, DoVariation10Times({0, 0}, 0)).
+
+
+do_variation_10_times({TrueCounter, FalseCounter}, 20) -> {TrueCounter, FalseCounter};
+do_variation_10_times({TrueCounter, FalseCounter}, AccuIn) ->
+  Counter = AccuIn + 1,
+  TargetIdentifierNumber = integer_to_binary(Counter),
+  DynamicTarget = #{'identifier' => <<"target",TargetIdentifierNumber/binary>>,
+    name => <<"targetname",TargetIdentifierNumber/binary>>,
+    anonymous => <<"">>
+  },
+  case cfclient_evaluator:bool_variation(<<"My_boolean_flag">>, DynamicTarget) of
+    {ok,true} ->
+      do_variation_10_times({TrueCounter + 1, FalseCounter + 0}, Counter);
+    {ok,false} ->
+      do_variation_10_times({TrueCounter + 0, FalseCounter + 1}, Counter)
+  end.
+
+
 
 %%  logger:error("True Counter: ~p~n \n False Counter ~p~n: ", [TrueCounter, FalseCounter]),
 %%%%  ?assertEqual({ok,false}, cfclient_evaluator:bool_variation(<<"My_boolean_flag">>, TargetIncludedFromGroup)),

--- a/src/cfclient_evaluator_test_data.erl
+++ b/src/cfclient_evaluator_test_data.erl
@@ -2,7 +2,12 @@
 -author("erowlands").
 
 %% API
--export([json_flag_only_groups/0, target_group_for_percentage_rollout/0, target_group/0, json_flag_targets_and_groups/0, json_flag_no_targets_or_groups/0, json_flag_only_targets/0, json_flag_off/0, number_flag_only_groups/0, number_flag_no_targets_or_groups/0, number_flag_only_targets/0, number_flag_off/0, string_flag_target_and_groups/0, string_flag_no_targets_or_groups/0, string_flag_off/0, boolean_flag_single_target/0, boolean_flag_group_only/0, boolean_flag_no_targets_or_groups/0, boolean_flag_off/0, percentage_rollout_boolean_50_50/0, percentage_rollout_boolean_100_true/0]).
+-export([json_flag_only_groups/0, target_group_for_percentage_rollout/0, target_group/0, json_flag_targets_and_groups/0,
+  json_flag_no_targets_or_groups/0, json_flag_only_targets/0, json_flag_off/0, number_flag_only_groups/0,
+  number_flag_no_targets_or_groups/0, number_flag_only_targets/0, number_flag_off/0, string_flag_target_and_groups/0,
+  string_flag_no_targets_or_groups/0, string_flag_off/0, boolean_flag_single_target/0, boolean_flag_group_only/0,
+  boolean_flag_no_targets_or_groups/0, boolean_flag_off/0, percentage_rollout_boolean_50_50/0, percentage_rollout_boolean_100_true/0,
+  percentage_rollout_boolean_100_false/0]).
 
 boolean_flag_off() ->
   #{defaultServe => #{variation => <<"true">>},
@@ -634,56 +639,3 @@ percentage_rollout_boolean_100_false() ->
       #{identifier => <<"false">>, name => <<"False">>,
         value => <<"false">>}],
     version => 4}.
-
-%%  #{defaultServe =>
-%%  #{variation =>
-%%  <<"true">>},
-%%    environment => <<"dev">>,
-%%    feature => <<"test">>,
-%%    kind => <<"boolean">>,
-%%    offVariation => <<"false">>,
-%%    prerequisites => [],
-%%    project =>
-%%    <<"erlangcustomrules">>,
-%%    rules =>
-%%    [#{clauses =>
-%%    [#{attribute =>
-%%    <<>>,
-%%      id =>
-%%      <<"3cd6a8c7-79d6-4697-b007-b8486f0568ba">>,
-%%      negate =>
-%%      false,
-%%      op =>
-%%      <<"segmentMatch">>,
-%%      values =>
-%%      [<<"group1">>]}],
-%%      priority => 0,
-%%      ruleId =>
-%%      <<"12410622-e1d1-46c9-acb3-e177c9dd4575">>,
-%%      serve =>
-%%      #{distribution =>
-%%      #{bucketBy =>
-%%      <<"identifier">>,
-%%        variations =>
-%%        [#{variation =>
-%%        <<"true">>,
-%%          weight =>
-%%          50},
-%%          #{variation =>
-%%          <<"false">>,
-%%            weight =>
-%%            50}]}}}],
-%%    state => <<"on">>,
-%%    variationToTargetMap =>
-%%    null,
-%%    variations =>
-%%    [#{identifier =>
-%%    <<"true">>,
-%%      name => <<"True">>,
-%%      value => <<"true">>},
-%%      #{identifier =>
-%%      <<"false">>,
-%%        name => <<"False">>,
-%%        value =>
-%%        <<"false">>}],
-%%    version => 4}.

--- a/src/cfclient_evaluator_test_data.erl
+++ b/src/cfclient_evaluator_test_data.erl
@@ -459,81 +459,81 @@ target_group_for_percentage_rollout() ->
         identifier => <<"target2">>,
         name => <<"target_2">>,
         org => <<>>,
-        project => <<>>}
+        project => <<>>},
       #{account => <<>>, environment => <<>>,
         identifier => <<"target3">>,
         name => <<"target_3">>,
         org => <<>>,
-        project => <<>>}
+        project => <<>>},
       #{account => <<>>, environment => <<>>,
         identifier => <<"target4">>,
         name => <<"target_4">>,
         org => <<>>,
-        project => <<>>}
+        project => <<>>},
       #{account => <<>>, environment => <<>>,
         identifier => <<"target5">>,
         name => <<"target_test">>,
         org => <<>>,
-        project => <<>>}
+        project => <<>>},
       #{account => <<>>, environment => <<>>,
         identifier => <<"target6">>,
         name => <<"target_test">>,
         org => <<>>,
-        project => <<>>}
+        project => <<>>},
       #{account => <<>>, environment => <<>>,
         identifier => <<"target7">>,
         name => <<"target_test">>,
         org => <<>>,
-        project => <<>>}
+        project => <<>>},
       #{account => <<>>, environment => <<>>,
         identifier => <<"target8">>,
         name => <<"target_test">>,
         org => <<>>,
-        project => <<>>}      #{account => <<>>, environment => <<>>,
+        project => <<>>},      #{account => <<>>, environment => <<>>,
         identifier => <<"target9">>,
         name => <<"target_test">>,
         org => <<>>,
-        project => <<>>}
+        project => <<>>},
       #{account => <<>>, environment => <<>>,
         identifier => <<"target10">>,
         name => <<"target_test">>,
         org => <<>>,
-        project => <<>>}
+        project => <<>>},
       #{account => <<>>, environment => <<>>,
         identifier => <<"target11">>,
         name => <<"target_test">>,
         org => <<>>,
-        project => <<>>}
+        project => <<>>},
       #{account => <<>>, environment => <<>>,
         identifier => <<"target12">>,
         name => <<"target_test">>,
         org => <<>>,
-        project => <<>>}
+        project => <<>>},
       #{account => <<>>, environment => <<>>,
         identifier => <<"target13">>,
         name => <<"target_test">>,
         org => <<>>,
-        project => <<>>}
+        project => <<>>},
       #{account => <<>>, environment => <<>>,
         identifier => <<"target14">>,
         name => <<"target_test">>,
         org => <<>>,
-        project => <<>>}
+        project => <<>>},
       #{account => <<>>, environment => <<>>,
         identifier => <<"target15">>,
         name => <<"target_test">>,
         org => <<>>,
-        project => <<>>}
+        project => <<>>},
       #{account => <<>>, environment => <<>>,
         identifier => <<"target16">>,
         name => <<"target_test">>,
         org => <<>>,
-        project => <<>>}
+        project => <<>>},
       #{account => <<>>, environment => <<>>,
         identifier => <<"target17">>,
         name => <<"target_test">>,
         org => <<>>,
-        project => <<>>}
+        project => <<>>},
       #{account => <<>>, environment => <<>>,
         identifier => <<"target18">>,
         name => <<"target_test">>,
@@ -555,7 +555,6 @@ target_group_for_percentage_rollout() ->
     version => 19}.
 
 percentage_rollout_boolean_50_50() ->
-
   #{defaultServe => #{variation => <<"true">>},
     environment => <<"dev">>, feature => <<"My_boolean_flag">>,
     kind => <<"boolean">>, offVariation => <<"false">>,

--- a/src/cfclient_evaluator_test_data.erl
+++ b/src/cfclient_evaluator_test_data.erl
@@ -608,6 +608,32 @@ percentage_rollout_boolean_100_true() ->
         value => <<"false">>}],
     version => 4}.
 
+percentage_rollout_boolean_100_false() ->
+  #{defaultServe => #{variation => <<"true">>},
+    environment => <<"dev">>, feature => <<"My_boolean_flag">>,
+    kind => <<"boolean">>, offVariation => <<"false">>,
+    prerequisites => [], project => <<"erlangsdktest">>,
+    rules =>
+    [#{clauses =>
+    [#{attribute => <<>>,
+      id => <<"d20dbdea-2b38-4343-b6fc-6fb09d41674d">>,
+      negate => false, op => <<"segmentMatch">>,
+      values => [<<"target_group_1">>]}],
+      priority => 0,
+      ruleId => <<"fbd0df98-2867-496d-8443-e3578236623d">>,
+      serve => #{distribution =>
+      #{bucketBy => <<"identifier">>,
+        variations =>
+        [#{variation => <<"true">>, weight => 0},
+          #{variation => <<"false">>, weight => 100}]}}}],
+    state => <<"on">>,
+    variationToTargetMap => null,
+    variations =>
+    [#{identifier => <<"true">>, name => <<"True">>,
+      value => <<"true">>},
+      #{identifier => <<"false">>, name => <<"False">>,
+        value => <<"false">>}],
+    version => 4}.
 
 %%  #{defaultServe =>
 %%  #{variation =>

--- a/src/cfclient_evaluator_test_data.erl
+++ b/src/cfclient_evaluator_test_data.erl
@@ -1,0 +1,639 @@
+-module(cfclient_evaluator_test_data).
+-author("erowlands").
+
+%% API
+-export([json_flag_only_groups/0, target_group_for_percentage_rollout/0, target_group/0, json_flag_targets_and_groups/0, json_flag_no_targets_or_groups/0, json_flag_only_targets/0, json_flag_off/0, number_flag_only_groups/0, number_flag_no_targets_or_groups/0, number_flag_only_targets/0, number_flag_off/0, string_flag_target_and_groups/0, string_flag_no_targets_or_groups/0, string_flag_off/0, boolean_flag_single_target/0, boolean_flag_group_only/0, boolean_flag_no_targets_or_groups/0, boolean_flag_off/0, percentage_rollout_boolean_50_50/0]).
+
+boolean_flag_off() ->
+  #{defaultServe => #{variation => <<"true">>},
+    environment => <<"dev">>, feature => <<"My_boolean_flag">>,
+    kind => <<"boolean">>, offVariation => <<"false">>,
+    prerequisites => [], project => <<"erlangsdktest">>,
+    rules =>
+    [#{clauses =>
+    [#{attribute => <<>>,
+      id => <<"d20dbdea-2b38-4343-b6fc-6fb09d41674d">>,
+      negate => false, op => <<"segmentMatch">>,
+      values => [<<"target_group_1">>]}],
+      priority => 0,
+      ruleId => <<"fbd0df98-2867-496d-8443-e3578236623d">>,
+      serve => #{variation => <<"true">>}}],
+    state => <<"off">>,
+    variationToTargetMap =>
+    [#{targets =>
+    [#{identifier => <<"target_identifier">>,
+      name => <<"target_test">>}],
+      variation => <<"true">>}],
+    variations =>
+    [#{identifier => <<"true">>, name => <<"True">>,
+      value => <<"true">>},
+      #{identifier => <<"false">>, name => <<"False">>,
+        value => <<"false">>}],
+    version => 4}.
+
+boolean_flag_no_targets_or_groups() ->
+  #{defaultServe => #{variation => <<"true">>},
+    environment => <<"dev">>, feature => <<"My_boolean_flag">>,
+    kind => <<"boolean">>, offVariation => <<"false">>,
+    prerequisites => [], project => <<"erlangsdktest">>,
+    rules => [],
+    state => <<"on">>,
+    variationToTargetMap => null,
+    variations =>
+    [#{identifier => <<"true">>, name => <<"True">>,
+      value => <<"true">>},
+      #{identifier => <<"false">>, name => <<"False">>,
+        value => <<"false">>}],
+    version => 4}.
+
+boolean_flag_group_only() ->
+  #{defaultServe => #{variation => <<"true">>},
+    environment => <<"dev">>, feature => <<"My_boolean_flag">>,
+    kind => <<"boolean">>, offVariation => <<"false">>,
+    prerequisites => [], project => <<"erlangsdktest">>,
+    rules =>
+    [#{clauses =>
+    [#{attribute => <<>>,
+      id => <<"d20dbdea-2b38-4343-b6fc-6fb09d41674d">>,
+      negate => false, op => <<"segmentMatch">>,
+      values => [<<"target_group_1">>]}],
+      priority => 0,
+      ruleId => <<"fbd0df98-2867-496d-8443-e3578236623d">>,
+      serve => #{variation => <<"false">>}}],
+    state => <<"on">>,
+    variationToTargetMap => null,
+    variations =>
+    [#{identifier => <<"true">>, name => <<"True">>,
+      value => <<"true">>},
+      #{identifier => <<"false">>, name => <<"False">>,
+        value => <<"false">>}],
+    version => 4}.
+
+boolean_flag_single_target() ->
+  #{defaultServe => #{variation => <<"true">>},
+    environment => <<"dev">>, feature => <<"My_boolean_flag">>,
+    kind => <<"boolean">>, offVariation => <<"false">>,
+    prerequisites => [], project => <<"erlangsdktest">>,
+    rules => [],
+    state => <<"on">>,
+    variationToTargetMap =>
+    [#{targets =>
+    [#{identifier => <<"target_identifier_2">>, name => <<"target_2">>},
+      #{identifier => <<"target_identifier_1">>, name => <<"target_1">>}],
+      variation => <<"false">>}],
+    variations =>
+    [#{identifier => <<"true">>, name => <<"True">>,
+      value => <<"true">>},
+      #{identifier => <<"false">>, name => <<"False">>,
+        value => <<"false">>}],
+    version => 4}.
+
+string_flag_off() ->
+  #{defaultServe => #{variation => <<"Serve_it">>},
+    environment => <<"dev">>, feature => <<"My_string_flag">>,
+    kind => <<"string">>, offVariation => <<"Dont_serve_it">>,
+    prerequisites => [], project => <<"erlangsdktest">>,
+    rules =>
+    [#{clauses =>
+    [#{attribute => <<>>,
+      id => <<"1e80543a-c78a-4543-94fa-8277ba8507c1">>,
+      negate => false, op => <<"segmentMatch">>,
+      values => [<<"target_group_2">>]}],
+      priority => 0,
+      ruleId => <<"2f81fac2-cb53-492c-b1e4-1d0766008a21">>,
+      serve => #{variation => <<"Dont_serve_it">>}}],
+    state => <<"off">>,
+    variationToTargetMap =>
+    [#{targets =>
+    [#{identifier => <<"target_test_1">>,
+      name => <<"target_test_1">>}],
+      variation => <<"Serve_it">>}],
+    variations =>
+    [#{identifier => <<"Serve_it">>, name => <<"Serve it">>,
+      value => <<"serve it">>},
+      #{identifier => <<"Dont_serve_it">>,
+        name => <<"Don't serve it ">>,
+        value => <<"don't serve it">>}],
+    version => 2}.
+
+string_flag_no_targets_or_groups() ->
+  #{defaultServe => #{variation => <<"Serve_it">>},
+    environment => <<"dev">>, feature => <<"My_string_flag">>,
+    kind => <<"string">>, offVariation => <<"Dont_serve_it">>,
+    prerequisites => [], project => <<"erlangsdktest">>,
+    rules => [], state => <<"on">>, variationToTargetMap => null,
+    variations =>
+    [#{identifier => <<"Serve_it">>, name => <<"Serve it">>,
+      value => <<"serve it">>},
+      #{identifier => <<"Dont_serve_it">>,
+        name => <<"Don't serve it ">>,
+        value => <<"don't serve it">>}],
+    version => 2}.
+
+string_flag_target_and_groups() ->
+  #{defaultServe => #{variation => <<"Serve_it">>},
+    environment => <<"dev">>, feature => <<"My_string_flag">>,
+    kind => <<"string">>, offVariation => <<"Dont_serve_it">>,
+    prerequisites => [], project => <<"erlangsdktest">>,
+    rules =>
+    [#{clauses =>
+    [#{attribute => <<>>,
+      id => <<"1e80543a-c78a-4543-94fa-8277ba8507c1">>,
+      negate => false, op => <<"segmentMatch">>,
+      values => [<<"target_group_1">>]}],
+      priority => 0,
+      ruleId => <<"2f81fac2-cb53-492c-b1e4-1d0766008a21">>,
+      serve => #{variation => <<"Dont_serve_it">>}}],
+    state => <<"on">>,
+    variationToTargetMap =>
+    [#{targets =>
+    [#{identifier => <<"target_identifier_1">>,
+      name => <<"target_test_1">>}],
+      variation => <<"Dont_serve_it">>}],
+    variations =>
+    [#{identifier => <<"Serve_it">>, name => <<"Serve it">>,
+      value => <<"serve it">>},
+      #{identifier => <<"Dont_serve_it">>,
+        name => <<"Don't serve it ">>,
+        value => <<"don't serve it">>}],
+    version => 2}.
+
+number_flag_off() ->
+  #{defaultServe => #{variation => <<"Serve_an_int">>},
+    environment => <<"dev">>,
+    feature => <<"My_cool_number_flag">>, kind => <<"int">>,
+    offVariation => <<"Serve_a_zero_int">>, prerequisites => [],
+    project => <<"erlangsdktest">>,
+    rules =>
+    [#{clauses =>
+    [#{attribute => <<>>,
+      id => <<"a6818821-eaab-467c-ae1c-823b9798619d">>,
+      negate => false, op => <<"segmentMatch">>,
+      values => [<<"target_group_2">>]}],
+      priority => 0,
+      ruleId => <<"cf5cc01a-e2dc-442b-9d86-f4db6ac2a180">>,
+      serve => #{variation => <<"Serve_a_zero_float">>}},
+      #{clauses =>
+      [#{attribute => <<>>,
+        id => <<"8f2e5f62-0ee0-43e6-8a64-3a40fe72f9f2">>,
+        negate => false, op => <<"segmentMatch">>,
+        values => [<<"target_group_1">>]}],
+        priority => 1,
+        ruleId => <<"be265486-b7d8-4382-a27a-6a9b929de365">>,
+        serve => #{variation => <<"Serve_a_float">>}}],
+    state => <<"off">>,
+    variationToTargetMap =>
+    [#{targets =>
+    [#{identifier => <<"target_identifier_3434">>,
+      name => <<"target_test">>},
+      #{identifier => <<"target_test_1">>,
+        name => <<"target_test_3">>}],
+      variation => <<"Serve_an_int">>}],
+    variations =>
+    [#{identifier => <<"Serve_an_int">>, name => <<"Serve an int">>,
+      value => <<"12456">>},
+      #{identifier => <<"Serve_a_zero_int">>,
+        name => <<"Serve a zero int">>, value => <<"0">>},
+      #{identifier => <<"Serve_a_float">>,
+        name => <<"Serve a float">>, value => <<"1.55">>},
+      #{identifier => <<"Serve_a_zero_float">>,
+        name => <<"Serve a zero float">>, value => <<"0.001">>}],
+    version => 3}.
+
+number_flag_only_targets() ->
+  #{defaultServe => #{variation => <<"Serve_an_int">>},
+    environment => <<"dev">>,
+    feature => <<"My_cool_number_flag">>, kind => <<"int">>,
+    offVariation => <<"Serve_a_zero_int">>, prerequisites => [],
+    project => <<"erlangsdktest">>,
+    rules => [],
+    state => <<"on">>,
+    variationToTargetMap =>
+    [#{targets =>
+    [#{identifier => <<"target_identifier_3434">>,
+      name => <<"target_test">>},
+      #{identifier => <<"target_identifier_1">>,
+        name => <<"target_test_3">>}],
+      variation => <<"Serve_a_zero_int">>}],
+    variations =>
+    [#{identifier => <<"Serve_an_int">>, name => <<"Serve an int">>,
+      value => <<"12456">>},
+      #{identifier => <<"Serve_a_zero_int">>,
+        name => <<"Serve a zero int">>, value => <<"0">>},
+      #{identifier => <<"Serve_a_float">>,
+        name => <<"Serve a float">>, value => <<"1.55">>},
+      #{identifier => <<"Serve_a_zero_float">>,
+        name => <<"Serve a zero float">>, value => <<"0.001">>}],
+    version => 3}.
+
+
+number_flag_no_targets_or_groups() ->
+  #{defaultServe => #{variation => <<"Serve_an_int">>},
+    environment => <<"dev">>,
+    feature => <<"My_cool_number_flag">>, kind => <<"int">>,
+    offVariation => <<"Serve_a_zero_int">>, prerequisites => [],
+    project => <<"erlangsdktest">>,
+    rules => [],
+    state => <<"on">>,
+    variationToTargetMap => null,
+    variations =>
+    [#{identifier => <<"Serve_an_int">>, name => <<"Serve an int">>,
+      value => <<"12456">>},
+      #{identifier => <<"Serve_a_zero_int">>,
+        name => <<"Serve a zero int">>, value => <<"0">>},
+      #{identifier => <<"Serve_a_float">>,
+        name => <<"Serve a float">>, value => <<"1.55">>},
+      #{identifier => <<"Serve_a_zero_float">>,
+        name => <<"Serve a zero float">>, value => <<"0.001">>}],
+    version => 3}.
+
+number_flag_only_groups() ->
+  #{defaultServe => #{variation => <<"Serve_an_int">>},
+    environment => <<"dev">>,
+    feature => <<"My_cool_number_flag">>, kind => <<"int">>,
+    offVariation => <<"Serve_a_zero_int">>, prerequisites => [],
+    project => <<"erlangsdktest">>,
+    rules =>
+    [#{clauses =>
+    [#{attribute => <<>>,
+      id => <<"a6818821-eaab-467c-ae1c-823b9798619d">>,
+      negate => false, op => <<"segmentMatch">>,
+      values => [<<"target_group_1">>]}],
+      priority => 0,
+      ruleId => <<"cf5cc01a-e2dc-442b-9d86-f4db6ac2a180">>,
+      serve => #{variation => <<"Serve_a_zero_float">>}},
+      #{clauses =>
+      [#{attribute => <<>>,
+        id => <<"8f2e5f62-0ee0-43e6-8a64-3a40fe72f9f2">>,
+        negate => false, op => <<"segmentMatch">>,
+        values => [<<"target_group_1">>]}],
+        priority => 1,
+        ruleId => <<"be265486-b7d8-4382-a27a-6a9b929de365">>,
+        serve => #{variation => <<"Serve_a_float">>}}],
+    state => <<"on">>,
+    variationToTargetMap => null,
+    variations =>
+    [#{identifier => <<"Serve_an_int">>, name => <<"Serve an int">>,
+      value => <<"12456">>},
+      #{identifier => <<"Serve_a_zero_int">>,
+        name => <<"Serve a zero int">>, value => <<"0">>},
+      #{identifier => <<"Serve_a_float">>,
+        name => <<"Serve a float">>, value => <<"1.55">>},
+      #{identifier => <<"Serve_a_zero_float">>,
+        name => <<"Serve a zero float">>, value => <<"0.001">>}],
+    version => 3}.
+
+json_flag_off() ->
+  #{defaultServe => #{variation => <<"Serve_it">>},
+    environment => <<"dev">>,feature => <<"My_JSON_flag">>,
+    kind => <<"json">>,offVariation => <<"Dont_serve_it">>,
+    prerequisites => [],project => <<"erlangsdktest">>,
+    rules =>
+    [#{clauses =>
+    [#{attribute => <<>>,
+      id => <<"011331a7-2ea8-4db3-91f7-68729a566e86">>,
+      negate => false,op => <<"segmentMatch">>,
+      values => [<<"target_group_1">>]}],
+      priority => 0,
+      ruleId => <<"3f8be42e-c6b5-43ff-9d24-51d0e0027117">>,
+      serve => #{variation => <<"Dont_serve_it">>}}],
+    state => <<"off">>,variationToTargetMap => null,
+    variations =>
+    [#{identifier => <<"Serve_it">>,name => <<"Serve it">>,
+      value => <<"{    \"serveIt\":\"yes\" }">>},
+      #{identifier => <<"Dont_serve_it">>,
+        name => <<"Don't serve it">>,
+        value => <<"{    \"serveIt\":\"no\" }">>}],
+    version => 3}.
+
+json_flag_only_targets() ->
+  #{defaultServe => #{variation => <<"Serve_it">>},
+    environment => <<"dev">>,feature => <<"My_JSON_flag">>,
+    kind => <<"json">>,offVariation => <<"Dont_serve_it">>,
+    prerequisites => [],project => <<"erlangsdktest">>,
+    rules => [],state => <<"on">>,
+    variationToTargetMap =>
+    [#{targets =>
+    [#{identifier => <<"target_identifier_1">>,
+      name => <<"target_test_1">>},
+      #{identifier => <<"target_test_2">>,
+        name => <<"target_test_2">>}],
+      variation => <<"Dont_serve_it">>}],
+    variations =>
+    [#{identifier => <<"Serve_it">>,name => <<"Serve it">>,
+      value => <<"{    \"serveIt\":\"yes\" }">>},
+      #{identifier => <<"Dont_serve_it">>,
+        name => <<"Don't serve it">>,
+        value => <<"{    \"serveIt\":\"no\" }">>}],
+    version => 4}.
+
+json_flag_no_targets_or_groups() ->
+  #{defaultServe => #{variation => <<"Serve_it">>},
+    environment => <<"dev">>,feature => <<"My_JSON_flag">>,
+    kind => <<"json">>,offVariation => <<"Dont_serve_it">>,
+    prerequisites => [],project => <<"erlangsdktest">>,
+    rules => [],state => <<"on">>,
+    variationToTargetMap => null,
+    variations =>
+    [#{identifier => <<"Serve_it">>,name => <<"Serve it">>,
+      value => <<"{    \"serveIt\":\"yes\" }">>},
+      #{identifier => <<"Dont_serve_it">>,
+        name => <<"Don't serve it">>,
+        value => <<"{    \"serveIt\":\"no\" }">>}],
+    version => 4}.
+
+json_flag_only_groups() ->
+  #{defaultServe => #{variation => <<"Serve_it">>},
+    environment => <<"dev">>,feature => <<"My_JSON_flag">>,
+    kind => <<"json">>,offVariation => <<"Dont_serve_it">>,
+    prerequisites => [],project => <<"erlangsdktest">>,
+    rules =>
+    [#{clauses =>
+    [#{attribute => <<>>,
+      id => <<"bdaf96d2-1a65-44c3-b367-f0eb610e6e39">>,
+      negate => false,op => <<"segmentMatch">>,
+      values => [<<"target_group_1">>]}],
+      priority => 5,
+      ruleId => <<"1676d97b-59e9-44c3-9806-748206d85978">>,
+      serve => #{variation => <<"Maybe_serve_it">>}}]
+    ,state => <<"on">>,
+    variationToTargetMap => null,
+    variations =>
+    [#{identifier => <<"Serve_it">>,name => <<"Serve it">>,
+      value => <<"{    \"serveIt\":\"yes\" }">>},
+      #{identifier => <<"Dont_serve_it">>,
+        name => <<"Don't serve it">>,
+        value => <<"{    \"serveIt\":\"no\" }">>},
+      #{identifier => <<"Maybe_serve_it">>,
+        name => <<"Maybe serve it">>,
+        value => <<"{    \"serveIt\":\"maybe\" }">>}],
+    version => 4}.
+
+json_flag_targets_and_groups() ->
+  #{defaultServe => #{variation => <<"Serve_it">>},
+    environment => <<"dev">>,feature => <<"My_JSON_flag">>,
+    kind => <<"json">>,offVariation => <<"Dont_serve_it">>,
+    prerequisites => [],project => <<"erlangsdktest">>,
+    rules =>
+    [#{clauses =>
+    [#{attribute => <<>>,
+      id => <<"bdaf96d2-1a65-44c3-b367-f0eb610e6e39">>,
+      negate => false,op => <<"segmentMatch">>,
+      values => [<<"target_group_1">>]}],
+      priority => 5,
+      ruleId => <<"1676d97b-59e9-44c3-9806-748206d85978">>,
+      serve => #{variation => <<"Maybe_serve_it">>}}],
+    state => <<"on">>,
+    variationToTargetMap =>
+    [#{targets =>
+    [#{identifier => <<"target_identifier_1">>,
+      name => <<"target_test">>},
+      #{identifier => <<"target_test_2">>,
+        name => <<"target_test_2">>}],
+      variation => <<"Dont_serve_it">>}],
+    variations =>
+    [#{identifier => <<"Serve_it">>,name => <<"Serve it">>,
+      value => <<"{    \"serveIt\":\"yes\" }">>},
+      #{identifier => <<"Dont_serve_it">>,
+        name => <<"Don't serve it">>,
+        value => <<"{    \"serveIt\":\"no\" }">>},
+      #{description => <<>>,identifier => <<"Maybe_serve_it">>,
+        name => <<"Maybe serve it">>,
+        value => <<"{    \"serveIt\":\"maybe\" }">>}],
+    version => 8}.
+
+target_group() ->
+  #{environment => <<"dev">>,
+    excluded =>
+    [#{account => <<>>, environment => <<>>,
+      identifier => <<"target_that_has_been_excluded">>,
+      name => <<"target_test_2">>, org => <<>>, project => <<>>}],
+    identifier => <<"target_group_1">>,
+    included =>
+    [#{account => <<>>, environment => <<>>,
+      identifier => <<"target_that_has_been_inlcuded">>,
+      name => <<"target_test">>, org => <<>>, project => <<>>}],
+    name => <<"target_group_1">>,
+    rules =>
+    [#{attribute => <<"location">>,
+      id => <<"493945ee-b37b-466d-900e-846a24c93bec">>,
+      negate => false,op => <<"ends_with">>,
+      values => [<<"1">>]},
+      #{attribute => <<"identifier">>,
+        id => <<"7f779368-036c-40e3-a8b7-8b69bd809f39">>,
+        negate => false,op => <<"ends_with">>,
+        values => [<<"2">>]},
+      #{attribute => <<"ab_testing">>,
+        id => <<"06bcb37b-111b-41c2-805a-d232e5e3dd11">>,
+        negate => false,op => <<"starts_with">>,
+        values => [<<"focus_group">>]},
+      #{attribute => <<"ab_testing">>,
+        id => <<"06bcb37b-111b-41c2-805a-d232e5e3dd11">>,
+        negate => false,op => <<"equal">>,
+        values => [<<"new_users">>]},
+      #{attribute => <<"ab_testing">>,
+        id => <<"06bcb37b-111b-41c2-805a-d232e5e3dd11">>,
+        negate => false,op => <<"equal_sensitive">>,
+        values => [<<"GREAT_GROUP">>]},
+      #{attribute => <<"beta">>,
+        id => <<"06bcb37b-111b-41c2-805a-d232e5e3dd11">>,
+        negate => false,op => <<"in">>,
+        values => [<<"target_999">>, <<"target_1000">>]}],
+    version => 19}.
+
+target_group_for_percentage_rollout() ->
+  #{environment => <<"dev">>,
+    excluded =>
+    [#{account => <<>>, environment => <<>>,
+      identifier => <<"target_that_has_been_excluded">>,
+      name => <<"target_test_2">>, org => <<>>, project => <<>>}],
+    identifier => <<"target_group_1">>,
+    included =>
+    [
+      #{account => <<>>, environment => <<>>,
+        identifier => <<"target1">>,
+        name => <<"target_1">>,
+        org => <<>>,
+        project => <<>>},
+      #{account => <<>>, environment => <<>>,
+        identifier => <<"target2">>,
+        name => <<"target_2">>,
+        org => <<>>,
+        project => <<>>}
+      #{account => <<>>, environment => <<>>,
+        identifier => <<"target3">>,
+        name => <<"target_3">>,
+        org => <<>>,
+        project => <<>>}
+      #{account => <<>>, environment => <<>>,
+        identifier => <<"target4">>,
+        name => <<"target_4">>,
+        org => <<>>,
+        project => <<>>}
+      #{account => <<>>, environment => <<>>,
+        identifier => <<"target5">>,
+        name => <<"target_test">>,
+        org => <<>>,
+        project => <<>>}
+      #{account => <<>>, environment => <<>>,
+        identifier => <<"target6">>,
+        name => <<"target_test">>,
+        org => <<>>,
+        project => <<>>}
+      #{account => <<>>, environment => <<>>,
+        identifier => <<"target7">>,
+        name => <<"target_test">>,
+        org => <<>>,
+        project => <<>>}
+      #{account => <<>>, environment => <<>>,
+        identifier => <<"target8">>,
+        name => <<"target_test">>,
+        org => <<>>,
+        project => <<>>}      #{account => <<>>, environment => <<>>,
+        identifier => <<"target9">>,
+        name => <<"target_test">>,
+        org => <<>>,
+        project => <<>>}
+      #{account => <<>>, environment => <<>>,
+        identifier => <<"target10">>,
+        name => <<"target_test">>,
+        org => <<>>,
+        project => <<>>}
+      #{account => <<>>, environment => <<>>,
+        identifier => <<"target11">>,
+        name => <<"target_test">>,
+        org => <<>>,
+        project => <<>>}
+      #{account => <<>>, environment => <<>>,
+        identifier => <<"target12">>,
+        name => <<"target_test">>,
+        org => <<>>,
+        project => <<>>}
+      #{account => <<>>, environment => <<>>,
+        identifier => <<"target13">>,
+        name => <<"target_test">>,
+        org => <<>>,
+        project => <<>>}
+      #{account => <<>>, environment => <<>>,
+        identifier => <<"target14">>,
+        name => <<"target_test">>,
+        org => <<>>,
+        project => <<>>}
+      #{account => <<>>, environment => <<>>,
+        identifier => <<"target15">>,
+        name => <<"target_test">>,
+        org => <<>>,
+        project => <<>>}
+      #{account => <<>>, environment => <<>>,
+        identifier => <<"target16">>,
+        name => <<"target_test">>,
+        org => <<>>,
+        project => <<>>}
+      #{account => <<>>, environment => <<>>,
+        identifier => <<"target17">>,
+        name => <<"target_test">>,
+        org => <<>>,
+        project => <<>>}
+      #{account => <<>>, environment => <<>>,
+        identifier => <<"target18">>,
+        name => <<"target_test">>,
+        org => <<>>,
+        project => <<>>},
+      #{account => <<>>, environment => <<>>,
+        identifier => <<"target19">>,
+        name => <<"target_test">>,
+        org => <<>>,
+        project => <<>>},
+      #{account => <<>>, environment => <<>>,
+        identifier => <<"target20">>,
+        name => <<"target_test">>,
+        org => <<>>,
+        project => <<>>}
+    ],
+    name => <<"target_group_1">>,
+    rules => [],
+    version => 19}.
+
+percentage_rollout_boolean_50_50() ->
+
+  #{defaultServe => #{variation => <<"true">>},
+    environment => <<"dev">>, feature => <<"My_boolean_flag">>,
+    kind => <<"boolean">>, offVariation => <<"false">>,
+    prerequisites => [], project => <<"erlangsdktest">>,
+    rules =>
+    [#{clauses =>
+    [#{attribute => <<>>,
+      id => <<"d20dbdea-2b38-4343-b6fc-6fb09d41674d">>,
+      negate => false, op => <<"segmentMatch">>,
+      values => [<<"target_group_1">>]}],
+      priority => 0,
+      ruleId => <<"fbd0df98-2867-496d-8443-e3578236623d">>,
+      serve => #{distribution =>
+      #{bucketBy => <<"identifier">>,
+      variations =>
+      [#{variation => <<"true">>, weight => 50},
+        #{variation => <<"false">>, weight => 50}]}}}],
+    state => <<"on">>,
+    variationToTargetMap => null,
+    variations =>
+    [#{identifier => <<"true">>, name => <<"True">>,
+      value => <<"true">>},
+      #{identifier => <<"false">>, name => <<"False">>,
+        value => <<"false">>}],
+    version => 4}.
+
+
+
+
+%%  #{defaultServe =>
+%%  #{variation =>
+%%  <<"true">>},
+%%    environment => <<"dev">>,
+%%    feature => <<"test">>,
+%%    kind => <<"boolean">>,
+%%    offVariation => <<"false">>,
+%%    prerequisites => [],
+%%    project =>
+%%    <<"erlangcustomrules">>,
+%%    rules =>
+%%    [#{clauses =>
+%%    [#{attribute =>
+%%    <<>>,
+%%      id =>
+%%      <<"3cd6a8c7-79d6-4697-b007-b8486f0568ba">>,
+%%      negate =>
+%%      false,
+%%      op =>
+%%      <<"segmentMatch">>,
+%%      values =>
+%%      [<<"group1">>]}],
+%%      priority => 0,
+%%      ruleId =>
+%%      <<"12410622-e1d1-46c9-acb3-e177c9dd4575">>,
+%%      serve =>
+%%      #{distribution =>
+%%      #{bucketBy =>
+%%      <<"identifier">>,
+%%        variations =>
+%%        [#{variation =>
+%%        <<"true">>,
+%%          weight =>
+%%          50},
+%%          #{variation =>
+%%          <<"false">>,
+%%            weight =>
+%%            50}]}}}],
+%%    state => <<"on">>,
+%%    variationToTargetMap =>
+%%    null,
+%%    variations =>
+%%    [#{identifier =>
+%%    <<"true">>,
+%%      name => <<"True">>,
+%%      value => <<"true">>},
+%%      #{identifier =>
+%%      <<"false">>,
+%%        name => <<"False">>,
+%%        value =>
+%%        <<"false">>}],
+%%    version => 4}.

--- a/src/cfclient_evaluator_test_data.erl
+++ b/src/cfclient_evaluator_test_data.erl
@@ -2,7 +2,7 @@
 -author("erowlands").
 
 %% API
--export([json_flag_only_groups/0, target_group_for_percentage_rollout/0, target_group/0, json_flag_targets_and_groups/0, json_flag_no_targets_or_groups/0, json_flag_only_targets/0, json_flag_off/0, number_flag_only_groups/0, number_flag_no_targets_or_groups/0, number_flag_only_targets/0, number_flag_off/0, string_flag_target_and_groups/0, string_flag_no_targets_or_groups/0, string_flag_off/0, boolean_flag_single_target/0, boolean_flag_group_only/0, boolean_flag_no_targets_or_groups/0, boolean_flag_off/0, percentage_rollout_boolean_50_50/0]).
+-export([json_flag_only_groups/0, target_group_for_percentage_rollout/0, target_group/0, json_flag_targets_and_groups/0, json_flag_no_targets_or_groups/0, json_flag_only_targets/0, json_flag_off/0, number_flag_only_groups/0, number_flag_no_targets_or_groups/0, number_flag_only_targets/0, number_flag_off/0, string_flag_target_and_groups/0, string_flag_no_targets_or_groups/0, string_flag_off/0, boolean_flag_single_target/0, boolean_flag_group_only/0, boolean_flag_no_targets_or_groups/0, boolean_flag_off/0, percentage_rollout_boolean_50_50/0, percentage_rollout_boolean_100_true/0]).
 
 boolean_flag_off() ->
   #{defaultServe => #{variation => <<"true">>},
@@ -581,7 +581,32 @@ percentage_rollout_boolean_50_50() ->
         value => <<"false">>}],
     version => 4}.
 
-
+percentage_rollout_boolean_100_true() ->
+  #{defaultServe => #{variation => <<"true">>},
+    environment => <<"dev">>, feature => <<"My_boolean_flag">>,
+    kind => <<"boolean">>, offVariation => <<"false">>,
+    prerequisites => [], project => <<"erlangsdktest">>,
+    rules =>
+    [#{clauses =>
+    [#{attribute => <<>>,
+      id => <<"d20dbdea-2b38-4343-b6fc-6fb09d41674d">>,
+      negate => false, op => <<"segmentMatch">>,
+      values => [<<"target_group_1">>]}],
+      priority => 0,
+      ruleId => <<"fbd0df98-2867-496d-8443-e3578236623d">>,
+      serve => #{distribution =>
+      #{bucketBy => <<"identifier">>,
+        variations =>
+        [#{variation => <<"true">>, weight => 100},
+          #{variation => <<"false">>, weight => 0}]}}}],
+    state => <<"on">>,
+    variationToTargetMap => null,
+    variations =>
+    [#{identifier => <<"true">>, name => <<"True">>,
+      value => <<"true">>},
+      #{identifier => <<"false">>, name => <<"False">>,
+        value => <<"false">>}],
+    version => 4}.
 
 
 %%  #{defaultServe =>


### PR DESCRIPTION
WHAT

Implements percentage rollout evaluations

TESTING

- Unit tests with Bool Variations for 50/50, 100/0, and 0/100 scenarios. 
- As we compute this using a hash, I compared the results with same dataset (Group and Targets) using Go and got the same results.

LARGE DIFF
Sorry about the noisy diff in `cfclient_evaluator_test.erl` - please focus on line 745 which includes the percentage rollout test cases. The diff is caused by moving out all the test data into its own file as the data was getting large.