### PR TITLE
Eunit Coverage

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -20,6 +20,7 @@
         {deps, [{meck, "0.9.2"}, {hackney, "1.18.1"}]},
         {erl_opts, [debug_info, export_all]},
         {eunit_compile_opts, [export_all]},
+        {cover_enabled, true},
         {eunit_opts, [verbose, {report,{eunit_surefire,[{dir,"eunit-reports/"}]}}]}
     ]}
 ]}.


### PR DESCRIPTION
What

Enables coverage for unit tests. 

Testing

Coverage generates when running `rebar coverage` and have tested locally and added `rebar coverage` to the pipeline and this works. 