### PR TITLE
Metrics: Respect Anonymous Target

### DIFF
--- a/src/cfclient_metrics.erl
+++ b/src/cfclient_metrics.erl
@@ -197,9 +197,8 @@ set_to_metric_target_cache(Target, MetricsTargetCachePID) ->
     true ->
       noop;
     false ->
-      MetricTarget = #{identifier => Identifier, name => maps:get(name, Target, Identifier), attributes => maps:get(attributes, Target, #{})},
       %% Key is identifier and value is the target itself
-      lru:add(MetricsTargetCachePID, Identifier, MetricTarget)
+      lru:add(MetricsTargetCachePID, Identifier, Target)
   end.
 
 

--- a/src/cfclient_metrics.erl
+++ b/src/cfclient_metrics.erl
@@ -182,7 +182,7 @@ set_to_metrics_cache(FlagIdentifier, Target, VariationIdentifier, VariationValue
 
 -spec set_to_metric_target_cache(Target :: cfclient:target(), MetricsTargetCachePID :: pid()) -> atom().
 set_to_metric_target_cache(Target, MetricsTargetCachePID) ->
-  %% Only store target if it's not anymous.
+  %% Only store target if it's not anonymous.
   case value_to_binary(maps:get(anonymous, Target, <<"false">>)) of
     <<"false">> ->
       Identifier = maps:get(identifier, Target),

--- a/test/cfclient_metrics_test.erl
+++ b/test/cfclient_metrics_test.erl
@@ -128,9 +128,11 @@ create_metric_data_test() ->
     }
   ],
 
-
   ?assertEqual(ExpectedMetrics, cfclient_metrics:create_metrics_data([UniqueEvaluation1, UniqueEvaluation2], CachePID, Timestamp, [])),
 
+  %%-------------------- No Unique Evaluations --------------------
+  ?assertEqual([], cfclient_metrics:create_metrics_data([], CachePID, Timestamp, [])),
+  
   lru:stop(CachePID).
 
 
@@ -203,37 +205,8 @@ create_metric_target_data_test() ->
   ],
   ?assertEqual(ExpectedMetricTargetData, sort_metric_target_list(cfclient_metrics:create_metric_target_data(UnusedKeys, UnusedCachePID, []))),
 
-%%-------------------- Three Public Targets and One Anonymous --------------------
-  AnonymousTarget1 = #{'identifier' => <<"target_999">>,
-    name => <<"target_name_999">>,
-    anonymous => <<"true">>,
-    attributes => #{location => <<"top_secret">>}
-  },
-
-  meck:sequence(lru, get, 2, [PublicTarget1, PublicTarget2, PublicTarget3, AnonymousTarget1]),
-
-  ?assertEqual(ExpectedMetricTargetData, sort_metric_target_list(cfclient_metrics:create_metric_target_data(UnusedKeys, UnusedCachePID, []))),
-
-  %%-------------------- Three Anonymous Targets --------------------
-  AnonymousTarget1 = #{'identifier' => <<"target_999">>,
-    name => <<"target_name_999">>,
-    anonymous => <<"true">>,
-    attributes => #{location => <<"top_secret">>}
-  },
-  AnonymousTarget2 = #{'identifier' => <<"target_888">>,
-    name => <<"target_name_888">>,
-    anonymous => <<"true">>,
-    attributes => #{location => <<"top_secret">>}
-  },
-  AnonymousTarget3 = #{'identifier' => <<"target_777">>,
-    name => <<"target_name_777">>,
-    anonymous => <<"true">>,
-    attributes => #{location => <<"top_secret">>}
-  },
-
-  meck:sequence(lru, get, 2, [AnonymousTarget1, AnonymousTarget2, AnonymousTarget3]),
-
-  ?assertEqual([], cfclient_metrics:create_metric_target_data(UnusedKeys, UnusedCachePID, [])).
+%%-------------------- No Targets --------------------
+  ?assertEqual([], cfclient_metrics:create_metric_target_data([], UnusedCachePID, [])).
 
 %% helper function that allows us to compare list equality for metric target data
 sort_metric_target_list(MetricTargetData) ->


### PR DESCRIPTION
# What

We were previously saving Targets to the metrics cache with only `identifier`, `name` and `attributes` to be efficient with space. However, when registering a Target we need to know if it's anonymous, so this change just saves the original Target to the cache and doesn't alter any fields. 

# Why

So anonymous targets don't get registered with ff-server 

# Testing

- tested with a single anonymous target which results in a payload `[]` for `targetData` - the unique metric event still got registered but the anonymous target did not. 