### PR TITLE
FFM-6137 - Change naming convention for project gen servers

### DIFF
--- a/src/cfclient.erl
+++ b/src/cfclient.erl
@@ -136,7 +136,7 @@ json_variation(FlagKey, Target, Default) when is_binary(FlagKey) ->
 -spec enqueue_metrics(IsAnalyticsEnabled :: boolean(), FlagIdentifier :: binary(), Target :: target(), VariationIdentifier :: binary(), VariationValue :: binary()) -> atom().
 enqueue_metrics(true, FlagIdentifier, Target, VariationIdentifier, VariationValue) ->
   logger:debug("Analytics is enabled. Passing data to analytics module. FlagIdentifier: ~p Target: ~p Variation: ~pn", [FlagIdentifier, Target, VariationValue]),
-  cfclient_metrics:enqueue_metrics(FlagIdentifier, Target, VariationIdentifier, VariationValue);
+  cfclient_metrics_server:enqueue_metrics(FlagIdentifier, Target, VariationIdentifier, VariationValue);
 enqueue_metrics(false, FlagIdentifier, Target, _, VariationValue) ->
   logger:debug("Analytics not enabled, not passing data to analytics module. FlagIdentifier: ~p Target: ~p Variation: ~pn", [FlagIdentifier, Target, VariationValue]),
   ok.

--- a/src/cfclient_instance.erl
+++ b/src/cfclient_instance.erl
@@ -13,7 +13,7 @@
 -define(PARENTSUP, cfclient_sup).
 
 %% Child references
--define(POLL_PROCESSOR_CHILD_REF, cfclient_poll_processor).
+-define(POLL_SERVER_CHILD_REF, cfclient_poll_server).
 -define(LRU_CACHE_CHILD_REF, cfclient_lru).
 -define(METRICS_GEN_SERVER_CHILD_REF, cfclient_metrics_server).
 -define(METRICS_CACHE_CHILD_REF, cfclient_metrics_server_lru).
@@ -98,7 +98,7 @@ start_children() ->
     false -> ok
   end,
   %% Start Poll Processor
-  {ok, _} = supervisor:start_child(?PARENTSUP, {?POLL_PROCESSOR_CHILD_REF, {cfclient_poll_processor, start_link, []}, permanent, 5000, worker, ['cfclient_poll_processor']}),
+  {ok, _} = supervisor:start_child(?PARENTSUP, {?POLL_SERVER_CHILD_REF, {cfclient_poll_server, start_link, []}, permanent, 5000, worker, ['cfclient_poll_server']}),
   ok.
 
 -spec stop_children(Children :: list()) -> ok.

--- a/src/cfclient_instance.erl
+++ b/src/cfclient_instance.erl
@@ -15,9 +15,9 @@
 %% Child references
 -define(POLL_PROCESSOR_CHILD_REF, cfclient_poll_processor).
 -define(LRU_CACHE_CHILD_REF, cfclient_lru).
--define(METRICS_GEN_SERVER_CHILD_REF, cfclient_metrics).
--define(METRICS_CACHE_CHILD_REF, cfclient_metrics_lru).
--define(METRIC_TARGET_CACHE_CHILD_REF, cfclient_metrics_target_lru).
+-define(METRICS_GEN_SERVER_CHILD_REF, cfclient_metrics_server).
+-define(METRICS_CACHE_CHILD_REF, cfclient_metrics_server_lru).
+-define(METRIC_TARGET_CACHE_CHILD_REF, cfclient_metrics_server_target_lru).
 
 
 -spec start(ApiKey :: string()) -> ok.
@@ -90,11 +90,11 @@ start_children() ->
     true ->
       %% Start metrics and metrics target caches
       {ok, MetricsCachePID} = supervisor:start_child(?PARENTSUP, {?METRICS_CACHE_CHILD_REF, {lru, start_link, [[{max_size, 32000000}]]}, permanent, 5000, worker, ['lru']}),
-      cfclient_metrics:set_metrics_cache_pid(MetricsCachePID),
+      cfclient_metrics_server:set_metrics_cache_pid(MetricsCachePID),
       {ok, MetricsTargetCachePID} = supervisor:start_child(?PARENTSUP, {?METRIC_TARGET_CACHE_CHILD_REF, {lru, start_link, [[{max_size, 32000000}]]}, permanent, 5000, worker, ['lru']}),
-      cfclient_metrics:set_metrics_target_cache_pid(MetricsTargetCachePID),
+      cfclient_metrics_server:set_metrics_target_cache_pid(MetricsTargetCachePID),
       %% Start metrics gen server
-      {ok, _} = supervisor:start_child(?PARENTSUP, {?METRICS_GEN_SERVER_CHILD_REF, {cfclient_metrics, start_link, []}, permanent, 5000, worker, ['cfclient_metrics']});
+      {ok, _} = supervisor:start_child(?PARENTSUP, {?METRICS_GEN_SERVER_CHILD_REF, {cfclient_metrics_server, start_link, []}, permanent, 5000, worker, ['cfclient_metrics_server']});
     false -> ok
   end,
   %% Start Poll Processor

--- a/src/cfclient_metrics_server.erl
+++ b/src/cfclient_metrics_server.erl
@@ -2,7 +2,7 @@
 %%% @doc
 
 %%% @end
--module(cfclient_metrics).
+-module(cfclient_metrics_server).
 
 -behaviour(gen_server).
 
@@ -11,7 +11,7 @@
 -include("cfclient_metrics_attributes.hrl").
 
 -define(SERVER, ?MODULE).
--record(cfclient_metrics_state, {analytics_push_interval, metrics_cache_pid, metric_target_cache_pid}).
+-record(cfclient_metrics_server_state, {analytics_push_interval, metrics_cache_pid, metric_target_cache_pid}).
 
 start_link() ->
   gen_server:start_link({local, ?SERVER}, ?MODULE, [], []).
@@ -20,7 +20,7 @@ init([]) ->
   AnalyticsPushInterval = cfclient_config:get_value(analytics_push_interval),
   MetricsCachePID = get_metrics_cache_pid(),
   MetricTargetCachePID = get_metric_target_cache_pid(),
-  State = #cfclient_metrics_state{analytics_push_interval = AnalyticsPushInterval, metrics_cache_pid = MetricsCachePID, metric_target_cache_pid = MetricTargetCachePID},
+  State = #cfclient_metrics_server_state{analytics_push_interval = AnalyticsPushInterval, metrics_cache_pid = MetricsCachePID, metric_target_cache_pid = MetricTargetCachePID},
   metrics_interval(AnalyticsPushInterval, MetricsCachePID, MetricTargetCachePID),
   {ok, State}.
 
@@ -30,7 +30,7 @@ handle_call(_Request, _From, State) ->
 handle_cast(_Request, State) ->
   {noreply, State}.
 
-handle_info(_Info, State = #cfclient_metrics_state{analytics_push_interval = AnalyticsPushInterval, metrics_cache_pid = MetricsCachePID, metric_target_cache_pid = MetricTargetCachePID}) ->
+handle_info(_Info, State = #cfclient_metrics_server_state{analytics_push_interval = AnalyticsPushInterval, metrics_cache_pid = MetricsCachePID, metric_target_cache_pid = MetricTargetCachePID}) ->
   metrics_interval(AnalyticsPushInterval, MetricsCachePID, MetricTargetCachePID),
   {noreply, State}.
 
@@ -227,5 +227,5 @@ reset_metrics_cache(MetricsCachePID) ->
 reset_metric_target_cache(MetricsTargetCachePID) ->
   lru:purge(MetricsTargetCachePID).
 
-terminate(_Reason, _State = #cfclient_metrics_state{}) ->
+terminate(_Reason, _State = #cfclient_metrics_server_state{}) ->
   ok.

--- a/src/cfclient_poll_server.erl
+++ b/src/cfclient_poll_server.erl
@@ -1,10 +1,9 @@
 %%%-------------------------------------------------------------------
 %%% @author bmjen
-%%% @copyright (C) 2022, <COMPANY>
 %%% @doc
 %%% @end
 %%%-------------------------------------------------------------------
--module(cfclient_poll_processor).
+-module(cfclient_poll_server).
 
 -behaviour(gen_server).
 
@@ -14,35 +13,35 @@
 
 -define(SERVER, ?MODULE).
 
--record(cfclient_poll_processor_state, {}).
+-record(cfclient_poll_server_state, {}).
 
 start_link() ->
   gen_server:start_link({local, ?SERVER}, ?MODULE, [], []).
 
 init([]) ->
-  logger:info("Starting poll processor"),
+  logger:info("Starting poll server"),
   PollInterval = cfclient_config:get_value(poll_interval),
   cfclient:retrieve_flags(),
   cfclient:retrieve_segments(),
   erlang:send_after(PollInterval, self(), trigger),
-  {ok, #cfclient_poll_processor_state{}}.
+  {ok, #cfclient_poll_server_state{}}.
 
-handle_call(_Request, _From, State = #cfclient_poll_processor_state{}) ->
+handle_call(_Request, _From, State = #cfclient_poll_server_state{}) ->
   {reply, ok, State}.
 
-handle_cast(_Request, State = #cfclient_poll_processor_state{}) ->
+handle_cast(_Request, State = #cfclient_poll_server_state{}) ->
   {noreply, State}.
 
-handle_info(_Info, State = #cfclient_poll_processor_state{}) ->
-  logger:info("Triggering poll processor"),
+handle_info(_Info, State = #cfclient_poll_server_state{}) ->
+  logger:info("Triggering poll server"),
   PollInterval = cfclient_config:get_value(poll_interval),
   cfclient:retrieve_flags(),
   cfclient:retrieve_segments(),
   erlang:send_after(PollInterval, self(), trigger),
   {noreply, State}.
 
-terminate(_Reason, _State = #cfclient_poll_processor_state{}) ->
+terminate(_Reason, _State = #cfclient_poll_server_state{}) ->
   ok.
 
-code_change(_OldVsn, State = #cfclient_poll_processor_state{}, _Extra) ->
+code_change(_OldVsn, State = #cfclient_poll_server_state{}, _Extra) ->
   {ok, State}.

--- a/test/cfclient_metrics_test.erl
+++ b/test/cfclient_metrics_test.erl
@@ -128,10 +128,10 @@ create_metric_data_test() ->
     }
   ],
 
-  ?assertEqual(ExpectedMetrics, cfclient_metrics:create_metrics_data([UniqueEvaluation1, UniqueEvaluation2], CachePID, Timestamp, [])),
+  ?assertEqual(ExpectedMetrics, cfclient_metrics_server:create_metrics_data([UniqueEvaluation1, UniqueEvaluation2], CachePID, Timestamp, [])),
 
   %%-------------------- No Unique Evaluations --------------------
-  ?assertEqual([], cfclient_metrics:create_metrics_data([], CachePID, Timestamp, [])),
+  ?assertEqual([], cfclient_metrics_server:create_metrics_data([], CachePID, Timestamp, [])),
   
   lru:stop(CachePID).
 
@@ -203,10 +203,10 @@ create_metric_target_data_test() ->
       attributes => PublicTarget3Attributes
     }
   ],
-  ?assertEqual(ExpectedMetricTargetData, sort_metric_target_list(cfclient_metrics:create_metric_target_data(UnusedKeys, UnusedCachePID, []))),
+  ?assertEqual(ExpectedMetricTargetData, sort_metric_target_list(cfclient_metrics_server:create_metric_target_data(UnusedKeys, UnusedCachePID, []))),
 
 %%-------------------- No Targets --------------------
-  ?assertEqual([], cfclient_metrics:create_metric_target_data([], UnusedCachePID, [])).
+  ?assertEqual([], cfclient_metrics_server:create_metric_target_data([], UnusedCachePID, [])).
 
 %% helper function that allows us to compare list equality for metric target data
 sort_metric_target_list(MetricTargetData) ->
@@ -235,7 +235,7 @@ create_metric_target_test() ->
       name => <<"target_name_2345">>,
       attributes => SingleBinaryAttributes
     },
-  ?assertEqual(SingleBinaryExpectedTarget, cfclient_metrics:create_metric_target(SingleBinaryTarget)),
+  ?assertEqual(SingleBinaryExpectedTarget, cfclient_metrics_server:create_metric_target(SingleBinaryTarget)),
 
   %% Multiple binary attributes
   MultipleBinaryTarget = #{'identifier' => <<"target_3333">>,
@@ -259,7 +259,7 @@ create_metric_target_test() ->
       name => <<"target_name_1444">>,
       attributes => MultipleBinaryAttributes
     },
-  ?assertEqual(MultipleBinaryExpectedTarget, cfclient_metrics:create_metric_target(MultipleBinaryTarget)),
+  ?assertEqual(MultipleBinaryExpectedTarget, cfclient_metrics_server:create_metric_target(MultipleBinaryTarget)),
 
   %%-------------------- Target with atom attributes --------------------
   %% Single atom attribute
@@ -279,7 +279,7 @@ create_metric_target_test() ->
       name => <<"target_name_1444">>,
       attributes => SingleAtomAttributes
     },
-  ?assertEqual(SingleAtomAttributeExpectedTarget, cfclient_metrics:create_metric_target(SingleAtomAttributeTarget)),
+  ?assertEqual(SingleAtomAttributeExpectedTarget, cfclient_metrics_server:create_metric_target(SingleAtomAttributeTarget)),
 
   %% Multiple atom attributes
   MultipleAtomAttributeTarget = #{'identifier' => <<"target_3333">>,
@@ -302,7 +302,7 @@ create_metric_target_test() ->
       name => <<"target_name_1444">>,
       attributes => MultipleAtomAttributes
     },
-  ?assertEqual(MultipleAtomAttributeExpectedTarget, cfclient_metrics:create_metric_target(MultipleAtomAttributeTarget)).
+  ?assertEqual(MultipleAtomAttributeExpectedTarget, cfclient_metrics_server:create_metric_target(MultipleAtomAttributeTarget)).
 
 %% Used for metric data - we just get more value spinning up a real cache vs mocking calls.
 start_lru_cache() ->


### PR DESCRIPTION
# What
Standardises gen server modules to have the prefix `_server`. Changed the following gen servers:

- polling
- metrics

# Why
To aid readability and follow naming convention best practices. 

# Testing
Ran sample app with polling and analytics enabled.