### PR TITLE
FFM-6242 Use release tag for cfapi

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -12,7 +12,6 @@
 
 {profiles, [
     {prod, [
-        {erl_opts, [no_debug_info]},
         {relx, [{dev_mode, false}]}
     ]},
     {test, [

--- a/rebar.config
+++ b/rebar.config
@@ -2,7 +2,7 @@
 
 {deps, [
     %% git dependencies
-    {cfapi, {git, "https://github.com/harness/ff-erlang-client-api", {branch, "main"}}},
+    {cfapi, {git, "https://github.com/harness/ff-erlang-client-api", {tag, "0.1.0-beta.1"}}},
     {erlang_murmurhash, {git, "https://github.com/harness-apps/erlang-murmurhash", {branch, "master"}}},
     {lru, "2.4.0"},
     {ctx, "0.6.0"},


### PR DESCRIPTION
# What
The cfapi dependency was set to use the `main` branch of that repo, as we never created any release there. I have created a beta release now and this PR updates to use that tag. 

- Also adds debug info to production releases, in line with other mainstream Erlang libraries. This makes it easier to debug the SDK when its used as a library in other applications.

# Why
To follow a proper release flow for the API