### PR TITLE
FFM-6966 Add option to use environment variable for API key

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,17 +72,17 @@ Add the library to `mix.exs` `deps()`:
 
 ### Erlang
 
-Provide your SDK key in `sys.config` using an environment variable:
+Provide your API key in `sys.config` using an environment variable:
 
 ```erlang
 [
   {cfclient, [
-    {api_key, {fun os:getenv/1, "YOUR_API_KEY_ENV_VARIABLE"},
+    {api_key, {environment_variable, "YOUR_API_KEY_ENV_VARIABLE"},
   ]}
 ].
 ```
 
-Or you may provide the SDK key directly if required:
+Or you may provide the API key directly if required:
 
 ```erlang
 [
@@ -94,7 +94,14 @@ Or you may provide the SDK key directly if required:
 
 ### Elixir
 
-Configure the application environment in `config/prod.exs`:
+Provide your API key in `config/prod.exs` using an environment variable: :
+
+```elixir
+config :cfclient,
+  api_key: System.get_env("YOUR_API_KEY_ENVIRONMENT_VARIABLE")
+```
+
+Or you may provide the API key directly if required:
 
 ```elixir
 config :cfclient,

--- a/README.md
+++ b/README.md
@@ -72,7 +72,17 @@ Add the library to `mix.exs` `deps()`:
 
 ### Erlang
 
-Configure the application environment in `sys.config`:
+Provide your SDK key in `sys.config` using an environment variable:
+
+```erlang
+[
+  {cfclient, [
+    {api_key, {fun os:getenv/1, "YOUR_API_KEY_ENV_VARIABLE"},
+  ]}
+].
+```
+
+Or you may provide the SDK key directly if required:
 
 ```erlang
 [

--- a/docs/further_reading.md
+++ b/docs/further_reading.md
@@ -5,15 +5,15 @@ Covers advanced topics (different config options and scenarios)
 ## Configuration Options
 The following configuration options are available to control the behaviour of the SDK.
 You can pass the configuration in as options when the SDK client is created.
-```python
-    # Create a Feature Flag Client
-    # Your applications sys.config file
-    [{cfclient, [
-        {api_key, "YOUR_API_KEY"},
-        {config, [
-            {config_url, "https://config.ff.harness.io/api/1.0"},
-            {events_url, "https://config.ff.harness.io/api/1.0"}
-        ]},
+```erlang
+%% Create a Feature Flag Client
+%% Create a Feature Flag ClientYour applications sys.config file
+[{cfclient, [
+    {api_key, {envrionment_variable, "YOUR_API_KEY_ENV_VARIABLE"},
+    {config, [
+        {config_url, "https://config.ff.harness.io/api/1.0"},
+        {events_url, "https://config.ff.harness.io/api/1.0"}
+    ]},
     ]}]
 ```
 

--- a/docs/further_reading.md
+++ b/docs/further_reading.md
@@ -10,10 +10,10 @@ You can pass the configuration in as options when the SDK client is created.
     # Your applications sys.config file
     [{cfclient, [
         {api_key, "YOUR_API_KEY"},
-        {config_url, "https://config.ff.harness.io/api/1.0"},
-        {events_url, "https://events.ff.harness.io/api/1.0"},
-        {poll_interval, 60000},
-        {analytics_push_interval, 60000}
+        {config, [
+            {config_url, "https://config.ff.harness.io/api/1.0"},
+            {events_url, "https://config.ff.harness.io/api/1.0"}
+        ]},
     ]}]
 ```
 

--- a/docs/further_reading.md
+++ b/docs/further_reading.md
@@ -2,12 +2,10 @@
 
 Covers advanced topics (different config options and scenarios)
 
-## Configuration Options
+## Erlang Configuration Options
 The following configuration options are available to control the behaviour of the SDK.
-You can pass the configuration in as options when the SDK client is created.
 ```erlang
-%% Create a Feature Flag Client
-%% Create a Feature Flag ClientYour applications sys.config file
+%% Your applications sys.config file
 [{cfclient, [
     {api_key, {envrionment_variable, "YOUR_API_KEY_ENV_VARIABLE"},
     {config, [
@@ -24,6 +22,8 @@ You can pass the configuration in as options when the SDK client is created.
 | poll_interval           | {poll_interval, 60000}                               | the interval in seconds that we poll for changes.                                                                                                | 60                                   |
 | analytics_push_interval | {analytics_push_interval, 60000}                     | the interval in seconds that we send analytics to the Harness Feature Flags service.                                                             | 60                                   |
 
+
+## TODO - Elixir flavour of options
 
 ## Recommended reading
 

--- a/src/cfclient_config.erl
+++ b/src/cfclient_config.erl
@@ -155,10 +155,7 @@ authenticate(nil, _Config) ->
 authenticate(ApiKey, Config) when is_list(ApiKey) -> authenticate(list_to_binary(ApiKey), Config);
 
 authenticate(ApiKeyFun, Config) when is_tuple(ApiKeyFun) ->
-  KeyFun = element(1, ApiKeyFun),
-  KeyFunArg1 = element(2, ApiKeyFun),
-  KeyFunArg2 = element(3, ApiKeyFun),
-  APIKey = KeyFun(KeyFunArg1, KeyFunArg2),
+  APIKey = build_api_key_fun(ApiKeyFun),
   authenticate(APIKey, Config);
 
 
@@ -174,6 +171,15 @@ authenticate(ApiKey, Config) ->
 
     {error, Response, _} -> {error, Response}
   end.
+
+build_api_key_fun({Fun, EnvVarArg, DefaultVarArg}) when is_function(Fun)->
+%%  KeyFun = element(1, ApiKeyFun),
+%%  KeyFunArg1 = element(2, ApiKeyFun),
+%%  KeyFunArg2 = element(3, ApiKeyFun),
+  Fun(EnvVarArg, DefaultVarArg);
+build_api_key_fun({_, _, _}) ->
+  ?LOG_ERROR("valid function not provided to retrieve API Key"),
+  {error, not_configured}.
 
 
 % TODO: validate the JWT

--- a/src/cfclient_config.erl
+++ b/src/cfclient_config.erl
@@ -153,8 +153,13 @@ authenticate(nil, _Config) ->
   {error, not_configured};
 
 authenticate({environment_variable, APIKeyEnvVar}, Config) ->
-  APIKey = os:getenv(APIKeyEnvVar),
-  authenticate(APIKey, Config);
+  case os:getenv(APIKeyEnvVar) of
+    false ->
+      ?LOG_ERROR("Environment variable for API Key not found"),
+      {error, not_configured};
+    APIKey ->
+      authenticate(APIKey, Config)
+  end;
 
 authenticate({key, APIKey}, Config) ->
   authenticate(APIKey, Config);

--- a/src/cfclient_config.erl
+++ b/src/cfclient_config.erl
@@ -154,7 +154,7 @@ authenticate(nil, _Config) ->
 
 authenticate(ApiKey, Config) when is_list(ApiKey) -> authenticate(list_to_binary(ApiKey), Config);
 
-authenticate(ApiKey, Config) when is_tuple(ApiKey) -> authenticate(ApiKey(), Config);
+authenticate(ApiKey, Config) when is_tuple(ApiKey) -> authenticate(element(1,ApiKey)(), Config);
 
 
 authenticate(ApiKey, Config) ->

--- a/src/cfclient_config.erl
+++ b/src/cfclient_config.erl
@@ -172,10 +172,13 @@ authenticate(ApiKey, Config) ->
     {error, Response, _} -> {error, Response}
   end.
 
+%%run_api_key_fun(APIKeyFun) when tuple_size(APIKeyFun) == 2->
+%%  {Fun, EnvVarArg} = APIKeyFun,
+%%  run_api_key_fun(APIKeyFun);
+
+run_api_key_fun({Fun, EnvVarArg}) when is_function(Fun)->
+  Fun(EnvVarArg);
 run_api_key_fun({Fun, EnvVarArg, DefaultVarArg}) when is_function(Fun)->
-%%  KeyFun = element(1, ApiKeyFun),
-%%  KeyFunArg1 = element(2, ApiKeyFun),
-%%  KeyFunArg2 = element(3, ApiKeyFun),
   Fun(EnvVarArg, DefaultVarArg);
 run_api_key_fun({_, _, _}) ->
   ?LOG_ERROR("valid function not provided to retrieve API Key"),

--- a/src/cfclient_config.erl
+++ b/src/cfclient_config.erl
@@ -177,9 +177,7 @@ authenticate(ApiKey, Config) ->
 %%  run_api_key_fun(APIKeyFun);
 
 run_api_key_fun({Fun, EnvVarArg}) when is_function(Fun)->
-  Fun(EnvVarArg, EnvVarArg);
-run_api_key_fun({Fun, EnvVarArg, DefaultVarArg}) when is_function(Fun)->
-  Fun(EnvVarArg, DefaultVarArg);
+  Fun(EnvVarArg);
 run_api_key_fun({_, _, _}) ->
   ?LOG_ERROR("valid function not provided to retrieve API Key"),
   {error, not_configured}.

--- a/src/cfclient_config.erl
+++ b/src/cfclient_config.erl
@@ -145,11 +145,11 @@ normalize_url(V) -> string:trim(V, trailing, "/").
 -spec authenticate(binary() | string() | undefined | nil, map()) ->
   {ok, Config :: map()} | {error, Response :: term()}.
 authenticate(undefined, _Config) ->
-  ?LOG_INFO("api_key undefined"),
+  ?LOG_ERROR("api_key undefined"),
   {error, not_configured};
 
 authenticate(nil, _Config) ->
-  ?LOG_INFO("api_key undefined"),
+  ?LOG_ERROR("api_key undefined"),
   {error, not_configured};
 
 authenticate(ApiKey, Config) when is_list(ApiKey) -> authenticate(list_to_binary(ApiKey), Config);
@@ -172,16 +172,11 @@ authenticate(ApiKey, Config) ->
     {error, Response, _} -> {error, Response}
   end.
 
-%%run_api_key_fun(APIKeyFun) when tuple_size(APIKeyFun) == 2->
-%%  {Fun, EnvVarArg} = APIKeyFun,
-%%  run_api_key_fun(APIKeyFun);
-
 run_api_key_fun({Fun, EnvVarArg}) when is_function(Fun)->
   Fun(EnvVarArg);
 run_api_key_fun({_, _, _}) ->
   ?LOG_ERROR("valid function not provided to retrieve API Key"),
   {error, not_configured}.
-
 
 % TODO: validate the JWT
 -spec parse_jwt(binary()) -> {ok, map()} | {error, Reason :: term()}.

--- a/src/cfclient_config.erl
+++ b/src/cfclient_config.erl
@@ -154,7 +154,7 @@ authenticate(nil, _Config) ->
 
 authenticate(ApiKey, Config) when is_list(ApiKey) -> authenticate(list_to_binary(ApiKey), Config);
 
-authenticate(ApiKey, Config) when is_function(ApiKey) -> authenticate(ApiKey(), Config);
+authenticate(ApiKey, Config) when is_tuple(ApiKey) -> authenticate(ApiKey(), Config);
 
 
 authenticate(ApiKey, Config) ->

--- a/src/cfclient_config.erl
+++ b/src/cfclient_config.erl
@@ -152,12 +152,14 @@ authenticate(nil, _Config) ->
   ?LOG_ERROR("api_key undefined"),
   {error, not_configured};
 
-authenticate(ApiKey, Config) when is_list(ApiKey) -> authenticate(list_to_binary(ApiKey), Config);
-
-authenticate(ApiKeyFun, Config) when is_tuple(ApiKeyFun) ->
-  APIKey = run_api_key_fun(ApiKeyFun),
+authenticate({environment_variable, APIKeyEnvVar}, Config) ->
+  APIKey = os:getenv(APIKeyEnvVar),
   authenticate(APIKey, Config);
 
+authenticate({key, APIKey}, Config) ->
+  authenticate(APIKey, Config);
+
+authenticate(ApiKey, Config) when is_list(ApiKey) -> authenticate(list_to_binary(ApiKey), Config);
 
 authenticate(ApiKey, Config) ->
   #{config_url := ConfigUrl} = Config,

--- a/src/cfclient_config.erl
+++ b/src/cfclient_config.erl
@@ -156,7 +156,9 @@ authenticate(ApiKey, Config) when is_list(ApiKey) -> authenticate(list_to_binary
 
 authenticate(ApiKeyFun, Config) when is_tuple(ApiKeyFun) ->
   KeyFun = element(1, ApiKeyFun),
-  APIKey = KeyFun(),
+  KeyFunArg1 = element(2, ApiKeyFun),
+  KeyFunArg2 = element(3, ApiKeyFun),
+  APIKey = KeyFun(KeyFunArg1, KeyFunArg2),
   authenticate(APIKey, Config);
 
 

--- a/src/cfclient_config.erl
+++ b/src/cfclient_config.erl
@@ -179,12 +179,6 @@ authenticate(ApiKey, Config) ->
     {error, Response, _} -> {error, Response}
   end.
 
-run_api_key_fun({Fun, EnvVarArg}) when is_function(Fun)->
-  Fun(EnvVarArg);
-run_api_key_fun({_, _, _}) ->
-  ?LOG_ERROR("valid function not provided to retrieve API Key"),
-  {error, not_configured}.
-
 % TODO: validate the JWT
 -spec parse_jwt(binary()) -> {ok, map()} | {error, Reason :: term()}.
 parse_jwt(JwtToken) ->

--- a/src/cfclient_config.erl
+++ b/src/cfclient_config.erl
@@ -161,9 +161,6 @@ authenticate({environment_variable, APIKeyEnvVar}, Config) ->
       authenticate(APIKey, Config)
   end;
 
-authenticate({key, APIKey}, Config) ->
-  authenticate(APIKey, Config);
-
 authenticate(ApiKey, Config) when is_list(ApiKey) -> authenticate(list_to_binary(ApiKey), Config);
 
 authenticate(ApiKey, Config) ->

--- a/src/cfclient_config.erl
+++ b/src/cfclient_config.erl
@@ -154,6 +154,9 @@ authenticate(nil, _Config) ->
 
 authenticate(ApiKey, Config) when is_list(ApiKey) -> authenticate(list_to_binary(ApiKey), Config);
 
+authenticate(ApiKey, Config) when is_function(ApiKey) -> authenticate(ApiKey(), Config);
+
+
 authenticate(ApiKey, Config) ->
   #{config_url := ConfigUrl} = Config,
   Opts = #{cfg => #{host => ConfigUrl}, params => #{apiKey => ApiKey}},

--- a/src/cfclient_config.erl
+++ b/src/cfclient_config.erl
@@ -179,7 +179,7 @@ authenticate(ApiKey, Config) ->
 run_api_key_fun({Fun, EnvVarArg}) when is_function(Fun)->
   Fun(EnvVarArg, EnvVarArg);
 run_api_key_fun({Fun, EnvVarArg, DefaultVarArg}) when is_function(Fun)->
-  Fun(EnvVarArg, EnvVarArg, DefaultVarArg);
+  Fun(EnvVarArg, DefaultVarArg);
 run_api_key_fun({_, _, _}) ->
   ?LOG_ERROR("valid function not provided to retrieve API Key"),
   {error, not_configured}.

--- a/src/cfclient_config.erl
+++ b/src/cfclient_config.erl
@@ -154,7 +154,10 @@ authenticate(nil, _Config) ->
 
 authenticate(ApiKey, Config) when is_list(ApiKey) -> authenticate(list_to_binary(ApiKey), Config);
 
-authenticate(ApiKey, Config) when is_tuple(ApiKey) -> authenticate(element(1,ApiKey)(), Config);
+authenticate(ApiKeyFun, Config) when is_tuple(ApiKeyFun) ->
+  KeyFun = element(1, ApiKeyFun),
+  APIKey = KeyFun(),
+  authenticate(APIKey, Config);
 
 
 authenticate(ApiKey, Config) ->

--- a/src/cfclient_config.erl
+++ b/src/cfclient_config.erl
@@ -177,9 +177,9 @@ authenticate(ApiKey, Config) ->
 %%  run_api_key_fun(APIKeyFun);
 
 run_api_key_fun({Fun, EnvVarArg}) when is_function(Fun)->
-  Fun(EnvVarArg);
+  Fun(EnvVarArg, EnvVarArg);
 run_api_key_fun({Fun, EnvVarArg, DefaultVarArg}) when is_function(Fun)->
-  Fun(EnvVarArg, DefaultVarArg);
+  Fun(EnvVarArg, EnvVarArg, DefaultVarArg);
 run_api_key_fun({_, _, _}) ->
   ?LOG_ERROR("valid function not provided to retrieve API Key"),
   {error, not_configured}.

--- a/src/cfclient_config.erl
+++ b/src/cfclient_config.erl
@@ -155,7 +155,7 @@ authenticate(nil, _Config) ->
 authenticate(ApiKey, Config) when is_list(ApiKey) -> authenticate(list_to_binary(ApiKey), Config);
 
 authenticate(ApiKeyFun, Config) when is_tuple(ApiKeyFun) ->
-  APIKey = build_api_key_fun(ApiKeyFun),
+  APIKey = run_api_key_fun(ApiKeyFun),
   authenticate(APIKey, Config);
 
 
@@ -172,12 +172,12 @@ authenticate(ApiKey, Config) ->
     {error, Response, _} -> {error, Response}
   end.
 
-build_api_key_fun({Fun, EnvVarArg, DefaultVarArg}) when is_function(Fun)->
+run_api_key_fun({Fun, EnvVarArg, DefaultVarArg}) when is_function(Fun)->
 %%  KeyFun = element(1, ApiKeyFun),
 %%  KeyFunArg1 = element(2, ApiKeyFun),
 %%  KeyFunArg2 = element(3, ApiKeyFun),
   Fun(EnvVarArg, DefaultVarArg);
-build_api_key_fun({_, _, _}) ->
+run_api_key_fun({_, _, _}) ->
   ?LOG_ERROR("valid function not provided to retrieve API Key"),
   {error, not_configured}.
 

--- a/src/cfclient_evaluator.erl
+++ b/src/cfclient_evaluator.erl
@@ -438,7 +438,7 @@ custom_attribute_to_binary(Value) when is_list(Value) ->
   case io_lib:char_list(Value) of
     % If user supplies a string/list then log an error as it is not a supported input
     true ->
-      ?LOG_WARNING(
+      ?LOG_ERROR(
         "Using strings/lists for element values in target custom attributes list is not supported"
       ),
       % TODO: deal with return value properly

--- a/src/cfclient_instance.erl
+++ b/src/cfclient_instance.erl
@@ -88,18 +88,12 @@ start_analytics(_) -> ok.
 retrieve_flags(#{poll_enabled := true} = Config) ->
   case cfclient_retrieve:retrieve_flags(Config) of
     {ok, Flags} -> [cfclient_cache:cache_flag(F, Config) || F <- Flags];
-    {error, Reason} -> ?LOG_WARNING("Could not retrive flags from API: ~p", [Reason])
+    {error, Reason} -> ?LOG_ERROR("Could not retrive flags from API: ~p", [Reason])
   end,
   case cfclient_retrieve:retrieve_segments(Config) of
     {ok, Segments} -> [cfclient_cache:cache_segment(S, Config) || S <- Segments];
-    {error, Reason1} -> ?LOG_WARNING("Could not retrive segments from API: ~p", [Reason1])
+    {error, Reason1} -> ?LOG_ERROR("Could not retrive segments from API: ~p", [Reason1])
   end,
   ok;
 
 retrieve_flags(_) -> ok.
-
-
-% Ensure value is binary
-% to_binary(Value) when is_binary(Value) -> Value;
-% to_binary(Value) when is_atom(Value) -> atom_to_binary(Value);
-% to_binary(Value) when is_list(Value) -> list_to_binary(Value).


### PR DESCRIPTION
# What 
Adds an option to use environment variable for API key. Elixir evaluates function calls in config files, but for Erlang you can pass in function definitions but they won't get evaluated so you must code the correct evaluation. Instead of doing that, this abstracts away the user having to put a function definition in the config file.

# Testing
Manual 
- SDK authenticates both with hard coded key and environment variable key