### PR TITLE
FFM-6967 Re-work how the SDK handles instances which fail to boot

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,8 @@ The following `sys.config` snippet starts up two additional instances as well al
   ]
 }].
 ```
+Note: if the default instance fails to start, for example due to an authentication error with the API key, then the SDK
+will fail to boot and the additional instances won't start.
 
 If you don't require the default instance to be started up, you can do:
 
@@ -312,7 +314,6 @@ for each of the additional project configurations you provided above. As the def
     
         Process.sleep(10000)
         getFlagLoop()
-      end
    
         # Default instance
         default_project_flag = "defaultflag"

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ If different parts of your application need to use specific [projects](https://d
 
 The additional project config is defined in `sys.config` 
 
-The following `sys.config` snippet starts up two additional instances as well as the default instance:
+The following `sys.config` snippet starts up two additional instances as well along with the default instance:
 
 ```erlang
 [
@@ -158,9 +158,11 @@ The following `sys.config` snippet starts up two additional instances as well as
 If you don't require the default instance to be started up, you can do:
 
 ```erlang
+  % ... additional project config
+
   {cfclient, [
     {start_default_instance, false},
-    %% The remaining tuples will be ignored, you can choose to include or omit them.
+    %% The remaining tuples will be ignored, so you can choose to include or omit them.
     {api_key, {environment_variable, "FF_API_KEY"}},
     {config, [
       {config_url, "https://config.ff.harness.io/api/1.0"},

--- a/README.md
+++ b/README.md
@@ -110,12 +110,14 @@ config :cfclient,
 
 ## Run multiple instances of the SDK
 
-Normally there is a single [project](https://developer.harness.io/docs/feature-flags/ff-using-flags/ff-creating-flag/create-a-project/) per application. If different parts of your
-application need to use specific projects, you can start up additional client instances using a `project_config` for each unique project. 
+The SDK by default starts up a single instance called `default` which is configured with your project API key.
+If different parts of your application need to use specific [projects](https://developer.harness.io/docs/feature-flags/ff-using-flags/ff-creating-flag/create-a-project/), you can start up additional client instances using by defining additional configuration for each unique project. 
 
-### Erlang Project Config
+### Erlang Project Config 
 
-The `project_config` is defined in `sys.config`:
+The additional project config is defined in `sys.config` 
+
+The following `sys.config` snippet starts up two additional instances as well as the default instance:
 
 ```erlang
 [
@@ -131,8 +133,8 @@ The `project_config` is defined in `sys.config`:
       %% The API key for the Harness project you want to use with this SDK instance.
       {api_key, {environment_variable, "PROJECT_1_API_KEY"}}]
     }
-  ]
-},
+  ]},
+  
   {harness_project_2_config, [
     {cfclient, [
       {config, [
@@ -140,11 +142,37 @@ The `project_config` is defined in `sys.config`:
       ]},
       {api_key, {environment_variable, "PROJECT_2_API_KEY"}}]
     }
-  ]].
+  ]},
+
+  {cfclient, [
+    {api_key, {environment_variable, "FF_API_KEY"}},
+    {config, [
+      {config_url, "https://config.ff.harness.io/api/1.0"},
+      {events_url, "https://config.ff.harness.io/api/1.0"}
+    ]},
+    {analytics_push_interval, 60000}
+  ]
+}].
+```
+
+If you don't require the default instance to be started up, you can do:
+
+```erlang
+  {cfclient, [
+    {start_default_instance, false},
+    %% The remaining tuples will be ignored, you can choose to include or omit them.
+    {api_key, {environment_variable, "FF_API_KEY"}},
+    {config, [
+      {config_url, "https://config.ff.harness.io/api/1.0"},
+      {events_url, "https://config.ff.harness.io/api/1.0"}
+    ]},
+    {analytics_push_interval, 60000}
+  ]
+},
 ```
 
 In your application supervisor, e.g. `src/myapp_sup.erl`, start up a `cfclient_instance`
-for each project. 
+for each additional project. As the default instance is booted when your application starts, you cannot (and don't need to) start it here. 
 
 ```erlang
 init(Args) ->
@@ -191,30 +219,112 @@ multi_instance_evaluations() ->
   Project2Result = cfclient:bool_variation(instance_name_2, Project2Flag, Target, false),
   logger:info("Instance name 2 Variation for Flag ~p with Target ~p is: ~p~n",
   [Project2Flag, maps:get(identifier, Target), Project2Result]).
+
+  %% Default instance
+  DefaultProjectFlag = <<"harnessappdemodarkmodeprojectdefault">>,
+  DefaultProjectResult = cfclient:bool_variation(Project2Flag, Target, false),
+  logger:info("Default instance Variation for Flag ~p with Target ~p is: ~p~n",
+  [DefaultProjectFlag, maps:get(identifier, Target), DefaultProjectResult]).
 ```
-This example demonstrates multiple instances of the SDK within the same application, but the same can be achieved if you have an application heirarchy where multiple applications need to use one or many instances of the Erlang SDK.
 
 ### Elixir
 
-Define the `api_key`:
+1. Create project configurations for each new instance you would like to start in your `config/config.exs` file:
 
-config :myapp, :cfclient,
-  api_key: "YOUR_API_KEY"
+    ```elixir
+    # Config for "project 1"
+    config :elixirsample,  project1:
+           [
+            api_key: System.get_env("FF_API_KEY_1"),
+            config: [name: :project1]
+           ]
+    
+    # Config for "project 2"
+    config :elixirsample,  project2:
+      [
+      api_key: System.get_env("FF_API_KEY_2"),
+      config: [name: :project2]
+    ]
+    ```
 
-In your application supervisor, e.g. `lib/myapp/supervisor.ex`, start up `cfclient_instance`:
+2. In your application supervisor, e.g. `lib/myapp/supervisor.ex`, start up `cfclient_instance` 
+for each of the additional project configurations you provided above. As the default instance is booted when your application starts, you cannot (and don't need to) start it here:
 
-```elixir
-def start(_type, _args) do
-  harness_args = Application.get_env(:myapp, :cfclient, [])
+    ```elixir
+      def init(_opts) do
+        project_1_config = Application.get_env(:elixirsample, :project1, [])
+        project_2_config = Application.get_env(:elixirsample, :project2, [])
+        children = [
+          %{
+            id: :project1_cfclient_instance,
+            start: {:cfclient_instance, :start_link, [project_1_config]},
+            type: :supervisor
+          },
+          %{
+            id: :project2_cfclient_instance,
+            start: {:cfclient_instance, :start_link, [project_2_config]},
+            type: :supervisor
+          },
+        ]
+        Supervisor.init(children, strategy: :one_for_one)
+      end
+    ```
 
-  children = [
-    %{id => :myapp_cfclient_instance, start => {:cfclient_instance, :start_link, [harness_args]}}
-  ]
+3. To use a specific SDK instance, you provide the instance name to the public function you are calling. For example use `bool_variation/4` instead of `bool_variation/3` - see the following code sample:
 
-  opts = [strategy: :one_for_one, name: MyApp.Supervisor]
-  Supervisor.start_link(children, opts)
-end
-```
+    ```elixir
+    defmodule ElixirSample.EvaluationSample do
+      require Logger
+    
+      def getFlagLoop() do
+        target = %{
+          identifier: "harness",
+          name: "Harness",
+          anonymous: false,
+          attributes: %{}
+        }
+    
+        # Default instance
+        flag = "projectflag"
+        result = :cfclient.bool_variation(flag, target, false)
+    
+        Logger.info(
+          "SVariation for Flag #{flag} with Target #{inspect(target)} is: #{result}"
+        )
+    
+        # Instance 1
+        project_1_flag = "project1flag"
+        project_1_result = :cfclient.number_variation(:project1, project_1_flag, target, 3)
+    
+        Logger.info(
+          "SDK instance 1: Variation for Flag #{project_1_flag} with Target #{inspect(target)} is: #{project_1_result}"
+        )
+    
+        # Instance 2
+        project_2_flag = "project2flag"
+        project_2_result = :cfclient.bool_variation(:project2, project_2_flag, target, false)
+    
+        Logger.info(
+          "SDK instance 2: Variation for Flag #{project_2_flag} with Target #{inspect(target)} is: #{project_2_result}"
+        )
+    
+        Process.sleep(10000)
+        getFlagLoop()
+      end
+   
+        # Default instance
+        default_project_flag = "defaultflag"
+        default_project_result = :cfclient.bool_variation(default_project_flag, target, false)
+    
+        Logger.info(
+          "Default instance: Variation for Flag #{default_project_flag} with Target #{inspect(target)} is: #{default_project_result}"
+        )
+    
+        Process.sleep(10000)
+        getFlagLoop()
+      end
+    end
+    ```
 
 ## Code Sample
 

--- a/src/cfclient_app.erl
+++ b/src/cfclient_app.erl
@@ -11,7 +11,8 @@
 start(_StartType, _StartArgs) ->
   ApiKey = application:get_env(cfclient, api_key, undefined),
   Config = application:get_env(cfclient, config, []),
-  cfclient_sup:start_link([{api_key, ApiKey}, {config, Config}]).
+  StartDefaultInstance = application:get_env(cfclient, start_default_instance, true),
+  cfclient_sup:start_link([{api_key, ApiKey}, {config, Config}, {start_default_instance, StartDefaultInstance}]).
 
 
 stop(_State) -> ok.

--- a/src/cfclient_config.erl
+++ b/src/cfclient_config.erl
@@ -144,12 +144,14 @@ normalize_url(V) -> string:trim(V, trailing, "/").
 % @doc with Authenticate with server and merge project attributes into config
 -spec authenticate(binary() | string() | undefined | nil, map()) ->
   {ok, Config :: map()} | {error, Response :: term()}.
-authenticate(undefined, _Config) ->
-  ?LOG_ERROR("api_key undefined"),
+authenticate(undefined, Config) ->
+  InstanceName = maps:get(name, Config),
+  ?LOG_ERROR("API key for instance '~p' is undefined", [InstanceName]),
   {error, not_configured};
 
-authenticate(nil, _Config) ->
-  ?LOG_ERROR("api_key undefined"),
+authenticate(nil, Config) ->
+  InstanceName = maps:get(name, Config),
+  ?LOG_ERROR("API key for instance '~p' is undefined", [InstanceName]),
   {error, not_configured};
 
 authenticate({environment_variable, APIKeyEnvVar}, Config) ->

--- a/src/cfclient_evaluator.erl
+++ b/src/cfclient_evaluator.erl
@@ -29,18 +29,6 @@
                 included => [map()] | null
               }.
 
-% -type cfapi_serving_rule() ::
-%     #{ 'ruleId' => binary(),
-%        'priority' := integer(),
-%        'clauses' := list(),
-%        'serve' := cfapi_serve:cfapi_serve()
-%      }.
-% "attribute": "identifier",
-%    "negate": false,
-%    "op": "equal",
-%    "values": [
-%        "one"
-%    ]
 -type target() :: cfclient:target().
 -type variation_map() :: #{
                          variation := binary(),

--- a/src/cfclient_instance.erl
+++ b/src/cfclient_instance.erl
@@ -46,7 +46,9 @@ init(Args) ->
               {ok, Config1}
           end;
         {error, Reason} ->
-          ?LOG_ERROR("Authentication failed: ~p", [Reason]),
+          InstanceName = maps:get(name, Config1),
+          ?LOG_ERROR("Authentication failed for cflient instance '~p': ~p", [InstanceName, Reason]),
+          ?LOG_ERROR("Unable to start the following cfclient instance: ~p", [InstanceName]),
           {stop, authenticate};
 
         {ok, Config} ->
@@ -54,6 +56,7 @@ init(Args) ->
           retrieve_flags(Config),
           start_poll(Config),
           start_analytics(Config),
+          ?LOG_INFO("Started unique instance of cfclient: ~p", [maps:get(name, Config1)]),
           {ok, Config}
       end;
     false ->

--- a/src/cfclient_instance.erl
+++ b/src/cfclient_instance.erl
@@ -36,7 +36,7 @@ init(Args) ->
   case cfclient_config:authenticate(ApiKey, Config1) of
     {error, not_configured} ->
       % Used during testing
-      {stop, authenticate};
+      {ok, Config1};
 
     {error, Reason} ->
       ?LOG_ERROR("Authentication failed: ~p", [Reason]),

--- a/src/cfclient_instance.erl
+++ b/src/cfclient_instance.erl
@@ -56,7 +56,7 @@ init(Args) ->
           start_analytics(Config),
           {ok, Config}
       end;
-    no_default_instance ->
+    {no_default_instance} ->
       default_instance_not_started
   end.
 

--- a/src/cfclient_instance.erl
+++ b/src/cfclient_instance.erl
@@ -42,7 +42,7 @@ init(Args) ->
           case maps:get(unit_test_mode, Config1, undefined) of
             undefined ->
               {stop, authenticate};
-            UnitTestMode ->
+            _UnitTestMode ->
               {ok, Config1}
           end;
         {error, Reason} ->

--- a/src/cfclient_instance.erl
+++ b/src/cfclient_instance.erl
@@ -35,9 +35,14 @@ init(Args) ->
   ok = cfclient_config:set_config(Config1),
   case cfclient_config:authenticate(ApiKey, Config1) of
     {error, not_configured} ->
-      % Used during testing
-      {ok, Config1};
-
+      % Used during testing to start up cfclient instances
+      % without a valid API key.
+      case maps:get(unit_test_mode, Config1, undefined) of
+        undefined ->
+          {stop, authenticate};
+        UnitTestMode ->
+          {ok, Config1}
+      end;
     {error, Reason} ->
       ?LOG_ERROR("Authentication failed: ~p", [Reason]),
       {stop, authenticate};

--- a/src/cfclient_instance.erl
+++ b/src/cfclient_instance.erl
@@ -36,7 +36,7 @@ init(Args) ->
   case cfclient_config:authenticate(ApiKey, Config1) of
     {error, not_configured} ->
       % Used during testing
-      {ok, Config1};
+      {stop, authenticate};
 
     {error, Reason} ->
       ?LOG_ERROR("Authentication failed: ~p", [Reason]),

--- a/src/cfclient_instance.erl
+++ b/src/cfclient_instance.erl
@@ -28,7 +28,7 @@
 start_link(Args) -> gen_server:start_link(?MODULE, Args, []).
 
 init(Args) ->
-  case proplists:get_value(no_default_instance, Args, undefined) of
+  case proplists:get_value(no_default_instance, Args) of
     undefined ->
       ApiKey = proplists:get_value(api_key, Args),
       Config0 = proplists:get_value(config, Args, []),

--- a/src/cfclient_instance.erl
+++ b/src/cfclient_instance.erl
@@ -5,8 +5,8 @@
 %% and flag usage metrics. It runs periodic tasks to pull data from
 %% the server and send metrics to it.
 %%
-%% An instance is started by the cfclient application.
-%% More complex applications can start additional instances for a specific
+%% An default instance is started by the cfclient application.
+%% Additional instances can be started if multiple Harness projects need to be used.
 %% project.
 %%
 %% @end

--- a/src/cfclient_instance.erl
+++ b/src/cfclient_instance.erl
@@ -28,8 +28,8 @@
 start_link(Args) -> gen_server:start_link(?MODULE, Args, []).
 
 init(Args) ->
-  case proplists:get_value(start_default_instance, Args) of
-    true ->
+  case proplists:get_value(start_default_instance, Args, true) of
+    true  ->
       ApiKey = proplists:get_value(api_key, Args),
       Config0 = proplists:get_value(config, Args, []),
       Config1 = cfclient_config:normalize(Config0),

--- a/src/cfclient_instance.erl
+++ b/src/cfclient_instance.erl
@@ -57,7 +57,7 @@ init(Args) ->
           {ok, Config}
       end;
     false ->
-      default_instance_not_started
+      {ok, default_instance_not_started}
   end.
 
 

--- a/src/cfclient_instance.erl
+++ b/src/cfclient_instance.erl
@@ -56,7 +56,7 @@ init(Args) ->
           start_analytics(Config),
           {ok, Config}
       end;
-    {no_default_instance} ->
+    _ ->
       default_instance_not_started
   end.
 

--- a/src/cfclient_instance.erl
+++ b/src/cfclient_instance.erl
@@ -28,8 +28,8 @@
 start_link(Args) -> gen_server:start_link(?MODULE, Args, []).
 
 init(Args) ->
-  case proplists:get_value(no_default_instance, Args) of
-    undefined ->
+  case proplists:get_value(start_default_instance, Args) of
+    true ->
       ApiKey = proplists:get_value(api_key, Args),
       Config0 = proplists:get_value(config, Args, []),
       Config1 = cfclient_config:normalize(Config0),
@@ -56,7 +56,7 @@ init(Args) ->
           start_analytics(Config),
           {ok, Config}
       end;
-    _ ->
+    false ->
       default_instance_not_started
   end.
 

--- a/src/cfclient_instance.erl
+++ b/src/cfclient_instance.erl
@@ -57,6 +57,7 @@ init(Args) ->
           {ok, Config}
       end;
     false ->
+      ?LOG_INFO("Default cfclient instance not started"),
       {ok, default_instance_not_started}
   end.
 

--- a/src/cfclient_metrics.erl
+++ b/src/cfclient_metrics.erl
@@ -201,19 +201,6 @@ target_attributes_to_metrics(_) -> [].
 target_attribute_to_metric({K, V}) ->
   #{key => K, value => cfclient_evaluator:custom_attribute_to_binary(V)}.
 
-% -spec get_metric(term(), config()) -> {ok, cfclient:target()} | {error, undefined}.
-% get_metric(Key, Config) ->
-%   MetricsCacheTable = cfclient_config:get_value(metrics_cache_table, Config),
-%   case ets:lookup(MetricsCacheTable, Key) of
-%     [] -> {error, undefined};
-%     [Value] -> {ok, Value}
-%   end.
-% -spec get_target(binary()) -> {ok, cfclient:target()} | {error, undefined}.
-% get_target(Key) ->
-%   case ets:lookup(?METRICS_TARGET_TABLE, Key) of
-%     [] -> {error, undefined};
-%     [Value] -> {ok, Value}
-%   end.
 -spec get_counter(term(), config()) -> {ok, integer()} | {error, undefined}.
 get_counter(Key, Config) ->
   #{metrics_counter_table := Table} = Config,

--- a/test/cfclient_ff_test_cases.erl
+++ b/test/cfclient_ff_test_cases.erl
@@ -63,7 +63,7 @@ evaluate_file(Path) ->
     setup,
     fun
       () ->
-        Config = [{name, ?MODULE}, {analytics_enabled, false}, {poll_enabled, false}],
+        Config = [{name, ?MODULE}, {analytics_enabled, false}, {poll_enabled, false}, {unit_test_mode, true}],
         {ok, Pid} = cfclient_instance:start_link([{config, Config}]),
         [cfclient_cache:cache_flag(F) || F <- Flags],
         [cfclient_cache:cache_segment(S) || S <- Segments],

--- a/test/cfclient_metrics_tests.erl
+++ b/test/cfclient_metrics_tests.erl
@@ -20,7 +20,7 @@ record_metric_data_test_() ->
     setup,
     fun
       () ->
-        Config = [{name, ?MODULE}, {poll_enabled, false}],
+        Config = [{name, ?MODULE}, {poll_enabled, false}, {unit_test_mode, true}],
         {ok, Pid} = cfclient_instance:start_link([{config, Config}]),
         Pid
     end,

--- a/test/cfclient_metrics_tests.erl
+++ b/test/cfclient_metrics_tests.erl
@@ -12,19 +12,15 @@
 
 -include("../src/cfclient_metrics_attributes.hrl").
 
-config() -> cfclient_config:get_config(?MODULE).
-
 record_metric_data_test_() ->
   {
     "Record Metric Data",
     setup,
     fun
       () ->
-        Config = [{name, ?MODULE}, {poll_enabled, false}],
-        {ok, Pid} = cfclient_instance:start_link([{config, Config}]),
-        Pid
+        Config = cfclient_config:defaults(),
+        ok = cfclient_config:create_tables(Config)
     end,
-    fun (Pid) -> gen_server:stop(Pid) end,
     [
       {
         "Two Unique Evaluations on same flag",
@@ -57,7 +53,7 @@ record_metric_data_test_() ->
             %     anonymous => <<"false">>,
             %     attributes => #{location => <<"us">>}
             %   },
-            Config = cfclient_config:get_config(?MODULE),
+            Config = cfclient_config:defaults(),
             cfclient_metrics:record(
               <<"flag1">>,
               UniqueEvaluationTarget1,
@@ -124,14 +120,14 @@ record_metric_data_test_() ->
             {ok, Metrics} = cfclient_metrics:collect_metrics_data(Timestamp, Config),
             % TODO: Flaky because metrics may be returned in different order. Sort results.
             ?assertMatch(ExpectedMetrics, lists:sort(Metrics))
-          % ?assertEqual(
-          %   ExpectedMetrics,
-          %   cfclient_metrics:create_metrics_data(
-          %     [UniqueEvaluation1, UniqueEvaluation2],
-          %     Timestamp,
-          %     []
-          %   )
-          % )
+        % ?assertEqual(
+        %   ExpectedMetrics,
+        %   cfclient_metrics:create_metrics_data(
+        %     [UniqueEvaluation1, UniqueEvaluation2],
+        %     Timestamp,
+        %     []
+        %   )
+        % )
         end
       }
       % {"No Unique Evaluations",

--- a/test/cfclient_metrics_tests.erl
+++ b/test/cfclient_metrics_tests.erl
@@ -12,15 +12,19 @@
 
 -include("../src/cfclient_metrics_attributes.hrl").
 
+config() -> cfclient_config:get_config(?MODULE).
+
 record_metric_data_test_() ->
   {
     "Record Metric Data",
     setup,
     fun
       () ->
-        Config = cfclient_config:defaults(),
-        ok = cfclient_config:create_tables(Config)
+        Config = [{name, ?MODULE}, {poll_enabled, false}],
+        {ok, Pid} = cfclient_instance:start_link([{config, Config}]),
+        Pid
     end,
+    fun (Pid) -> gen_server:stop(Pid) end,
     [
       {
         "Two Unique Evaluations on same flag",
@@ -53,7 +57,7 @@ record_metric_data_test_() ->
             %     anonymous => <<"false">>,
             %     attributes => #{location => <<"us">>}
             %   },
-            Config = cfclient_config:defaults(),
+            Config = cfclient_config:get_config(?MODULE),
             cfclient_metrics:record(
               <<"flag1">>,
               UniqueEvaluationTarget1,
@@ -120,14 +124,14 @@ record_metric_data_test_() ->
             {ok, Metrics} = cfclient_metrics:collect_metrics_data(Timestamp, Config),
             % TODO: Flaky because metrics may be returned in different order. Sort results.
             ?assertMatch(ExpectedMetrics, lists:sort(Metrics))
-        % ?assertEqual(
-        %   ExpectedMetrics,
-        %   cfclient_metrics:create_metrics_data(
-        %     [UniqueEvaluation1, UniqueEvaluation2],
-        %     Timestamp,
-        %     []
-        %   )
-        % )
+          % ?assertEqual(
+          %   ExpectedMetrics,
+          %   cfclient_metrics:create_metrics_data(
+          %     [UniqueEvaluation1, UniqueEvaluation2],
+          %     Timestamp,
+          %     []
+          %   )
+          % )
         end
       }
       % {"No Unique Evaluations",


### PR DESCRIPTION
# What
Improves the way the SDK deals with failures for individual instances in a multi-instance setup 

It now

1. Instead of the SDK continuing to boot if there was an auth error, essentially in a useless state, it now fails to boot and logs the instance name and reason.
2. Adds an option _not_ to start up the default instance. Helpful if users start up other instances but don't need the default instance to start.
3. If the default instance is enabled  and it fails to start because of an authentication issue, the SDK will no longer boot up so other instances won't start. 
4. If any instance fails to start, the error log will include the instance name and the error.

Updates readme, and I have raised a PR on the Erlang documentation to support these changes.

# Testing
Manual - in Erlang and Elxir sample apps.