### PR TITLE
FFM-8769 Extend percentage rollout unit tests

### DIFF
--- a/test/cfclient_evaluator_test_data.erl
+++ b/test/cfclient_evaluator_test_data.erl
@@ -952,7 +952,7 @@ percentage_rollout_boolean(Weight1, Weight2) ->
 
 percentage_rollout_multi_variate(Weight1, Weight2, Weight3) ->
   #{
-    defaultServe => #{variation => <<"true">>},
+    defaultServe => #{variation => <<"variation3">>},
     environment => <<"dev">>,
     feature => <<"My_string_flag">>,
     kind => <<"string">>,
@@ -985,7 +985,7 @@ percentage_rollout_multi_variate(Weight1, Weight2, Weight3) ->
             bucketBy => <<"identifier">>,
             variations
             =>
-            [#{variation => <<"variation1">>, weight => Weight1}, #{variation => <<"variation1">>, weight => Weight2},
+            [#{variation => <<"variation1">>, weight => Weight1}, #{variation => <<"variation2">>, weight => Weight2},
               #{variation => <<"variation3">>, weight => Weight3}]
           }
         }
@@ -996,8 +996,9 @@ percentage_rollout_multi_variate(Weight1, Weight2, Weight3) ->
     variations
     =>
     [
-      #{identifier => <<"true">>, name => <<"True">>, value => <<"true">>},
-      #{identifier => <<"false">>, name => <<"False">>, value => <<"false">>}
+      #{identifier => <<"variation1">>, name => <<"variation1">>, value => <<"variation1">>},
+      #{identifier => <<"variation2">>, name => <<"variation2">>, value => <<"variation2">>},
+      #{identifier => <<"variation3">>, name => <<"variation3">>, value => <<"variation3">>}
     ],
     version => 4
   }.

--- a/test/cfclient_evaluator_test_data.erl
+++ b/test/cfclient_evaluator_test_data.erl
@@ -30,7 +30,7 @@
   prerequisite_matches_flag_1/0,
   prerequisite_matches_flag_2/0,
   prerequisite_matches_flag_3/0
-  , generate_targets/2]).
+  , generate_targets/2, percentage_rollout_boolean_70_30/0]).
 
 boolean_flag_off() ->
   #{
@@ -1039,6 +1039,57 @@ percentage_rollout_boolean_100_false() ->
             variations
             =>
             [#{variation => <<"true">>, weight => 0}, #{variation => <<"false">>, weight => 100}]
+          }
+        }
+      }
+    ],
+    state => <<"on">>,
+    variationToTargetMap => null,
+    variations
+    =>
+    [
+      #{identifier => <<"true">>, name => <<"True">>, value => <<"true">>},
+      #{identifier => <<"false">>, name => <<"False">>, value => <<"false">>}
+    ],
+    version => 4
+  }.
+
+percentage_rollout_boolean_70_30() ->
+  #{
+    defaultServe => #{variation => <<"true">>},
+    environment => <<"dev">>,
+    feature => <<"My_boolean_flag">>,
+    kind => <<"boolean">>,
+    offVariation => <<"false">>,
+    prerequisites => [],
+    project => <<"erlangsdktest">>,
+    rules
+    =>
+    [
+      #{
+        clauses
+        =>
+        [
+          #{
+            attribute => <<>>,
+            id => <<"d20dbdea-2b38-4343-b6fc-6fb09d41674d">>,
+            negate => false,
+            op => <<"segmentMatch">>,
+            values => [<<"target_group_1">>]
+          }
+        ],
+        priority => 0,
+        ruleId => <<"fbd0df98-2867-496d-8443-e3578236623d">>,
+        serve
+        =>
+        #{
+          distribution
+          =>
+          #{
+            bucketBy => <<"identifier">>,
+            variations
+            =>
+            [#{variation => <<"true">>, weight => 70}, #{variation => <<"false">>, weight => 30}]
           }
         }
       }

--- a/test/cfclient_evaluator_test_data.erl
+++ b/test/cfclient_evaluator_test_data.erl
@@ -4,30 +4,35 @@
 
 %% API
 
--export([
-  json_flag_only_groups/0,
-  target_group_for_percentage_rollout/0,
-  target_group/0,
-  json_flag_targets_and_groups/0,
-  json_flag_no_targets_or_groups/0,
-  json_flag_only_targets/0,
-  json_flag_off/0,
-  number_flag_only_groups/0,
-  number_flag_no_targets_or_groups/0,
-  number_flag_only_targets/0,
-  number_flag_off/0,
-  string_flag_target_and_groups/0,
-  string_flag_no_targets_or_groups/0,
-  string_flag_off/0,
-  boolean_flag_single_target/0,
-  boolean_flag_group_only/0,
-  boolean_flag_no_targets_or_groups/0,
-  boolean_flag_off/0,
-  flag_with_three_prerequisites/0,
-  prerequisite_matches_flag_1/0,
-  prerequisite_matches_flag_2/0,
-  prerequisite_matches_flag_3/0
-  , generate_targets/2, percentage_rollout_boolean/2, percentage_rollout_multi_variate/3]).
+-export(
+  [
+    json_flag_only_groups/0,
+    target_group_for_percentage_rollout/0,
+    target_group/0,
+    json_flag_targets_and_groups/0,
+    json_flag_no_targets_or_groups/0,
+    json_flag_only_targets/0,
+    json_flag_off/0,
+    number_flag_only_groups/0,
+    number_flag_no_targets_or_groups/0,
+    number_flag_only_targets/0,
+    number_flag_off/0,
+    string_flag_target_and_groups/0,
+    string_flag_no_targets_or_groups/0,
+    string_flag_off/0,
+    boolean_flag_single_target/0,
+    boolean_flag_group_only/0,
+    boolean_flag_no_targets_or_groups/0,
+    boolean_flag_off/0,
+    flag_with_three_prerequisites/0,
+    prerequisite_matches_flag_1/0,
+    prerequisite_matches_flag_2/0,
+    prerequisite_matches_flag_3/0,
+    generate_targets/2,
+    percentage_rollout_boolean/2,
+    percentage_rollout_multi_variate/3
+  ]
+).
 
 boolean_flag_off() ->
   #{
@@ -862,11 +867,12 @@ generate_targets(Start, End) ->
       name => <<"target_test">>,
       org => <<>>,
       project => <<>>
-    } || N <- lists:seq(Start, End)
+    }
+    || N <- lists:seq(Start, End)
   ].
 
 target_group_for_percentage_rollout() ->
-   #{
+  #{
     environment => <<"dev">>,
     excluded
     =>
@@ -881,12 +887,12 @@ target_group_for_percentage_rollout() ->
       }
     ],
     identifier => <<"target_group_1">>,
-    included
-    =>
-%%    generate_targets(0, 5),
-    [],
+    %%    generate_targets(0, 5),
+    included => [],
     name => <<"target_group_1">>,
-    rules => [
+    rules
+    =>
+    [
       #{
         attribute => <<"identifier">>,
         id => <<"7f779368-036c-40e3-a8b7-8b69bd809f39">>,
@@ -934,7 +940,10 @@ percentage_rollout_boolean(Weight1, Weight2) ->
             bucketBy => <<"identifier">>,
             variations
             =>
-            [#{variation => <<"true">>, weight => Weight1}, #{variation => <<"false">>, weight => Weight2}]
+            [
+              #{variation => <<"true">>, weight => Weight1},
+              #{variation => <<"false">>, weight => Weight2}
+            ]
           }
         }
       }
@@ -985,8 +994,11 @@ percentage_rollout_multi_variate(Weight1, Weight2, Weight3) ->
             bucketBy => <<"identifier">>,
             variations
             =>
-            [#{variation => <<"variation1">>, weight => Weight1}, #{variation => <<"variation2">>, weight => Weight2},
-              #{variation => <<"variation3">>, weight => Weight3}]
+            [
+              #{variation => <<"variation1">>, weight => Weight1},
+              #{variation => <<"variation2">>, weight => Weight2},
+              #{variation => <<"variation3">>, weight => Weight3}
+            ]
           }
         }
       }

--- a/test/cfclient_evaluator_test_data.erl
+++ b/test/cfclient_evaluator_test_data.erl
@@ -23,14 +23,11 @@
   boolean_flag_group_only/0,
   boolean_flag_no_targets_or_groups/0,
   boolean_flag_off/0,
-  percentage_rollout_boolean_50_50/0,
-  percentage_rollout_boolean_100_true/0,
-  percentage_rollout_boolean_100_false/0,
   flag_with_three_prerequisites/0,
   prerequisite_matches_flag_1/0,
   prerequisite_matches_flag_2/0,
   prerequisite_matches_flag_3/0
-  , generate_targets/2, percentage_rollout_boolean_70_30/0]).
+  , generate_targets/2, percentage_rollout_boolean/2]).
 
 boolean_flag_off() ->
   #{
@@ -901,58 +898,8 @@ target_group_for_percentage_rollout() ->
     version => 19
   }.
 
-percentage_rollout_boolean_50_50() ->
-  #{
-    defaultServe => #{variation => <<"true">>},
-    environment => <<"dev">>,
-    feature => <<"My_boolean_flag">>,
-    kind => <<"boolean">>,
-    offVariation => <<"false">>,
-    prerequisites => [],
-    project => <<"erlangsdktest">>,
-    rules
-    =>
-    [
-      #{
-        clauses
-        =>
-        [
-          #{
-            attribute => <<>>,
-            id => <<"d20dbdea-2b38-4343-b6fc-6fb09d41674d">>,
-            negate => false,
-            op => <<"segmentMatch">>,
-            values => [<<"target_group_1">>]
-          }
-        ],
-        priority => 0,
-        ruleId => <<"fbd0df98-2867-496d-8443-e3578236623d">>,
-        serve
-        =>
-        #{
-          distribution
-          =>
-          #{
-            bucketBy => <<"identifier">>,
-            variations
-            =>
-            [#{variation => <<"true">>, weight => 50}, #{variation => <<"false">>, weight => 50}]
-          }
-        }
-      }
-    ],
-    state => <<"on">>,
-    variationToTargetMap => null,
-    variations
-    =>
-    [
-      #{identifier => <<"true">>, name => <<"True">>, value => <<"true">>},
-      #{identifier => <<"false">>, name => <<"False">>, value => <<"false">>}
-    ],
-    version => 4
-  }.
 
-percentage_rollout_boolean_100_true() ->
+percentage_rollout_boolean(Weight1, Weight2) ->
   #{
     defaultServe => #{variation => <<"true">>},
     environment => <<"dev">>,
@@ -987,109 +934,7 @@ percentage_rollout_boolean_100_true() ->
             bucketBy => <<"identifier">>,
             variations
             =>
-            [#{variation => <<"true">>, weight => 100}, #{variation => <<"false">>, weight => 0}]
-          }
-        }
-      }
-    ],
-    state => <<"on">>,
-    variationToTargetMap => null,
-    variations
-    =>
-    [
-      #{identifier => <<"true">>, name => <<"True">>, value => <<"true">>},
-      #{identifier => <<"false">>, name => <<"False">>, value => <<"false">>}
-    ],
-    version => 4
-  }.
-
-percentage_rollout_boolean_100_false() ->
-  #{
-    defaultServe => #{variation => <<"true">>},
-    environment => <<"dev">>,
-    feature => <<"My_boolean_flag">>,
-    kind => <<"boolean">>,
-    offVariation => <<"false">>,
-    prerequisites => [],
-    project => <<"erlangsdktest">>,
-    rules
-    =>
-    [
-      #{
-        clauses
-        =>
-        [
-          #{
-            attribute => <<>>,
-            id => <<"d20dbdea-2b38-4343-b6fc-6fb09d41674d">>,
-            negate => false,
-            op => <<"segmentMatch">>,
-            values => [<<"target_group_1">>]
-          }
-        ],
-        priority => 0,
-        ruleId => <<"fbd0df98-2867-496d-8443-e3578236623d">>,
-        serve
-        =>
-        #{
-          distribution
-          =>
-          #{
-            bucketBy => <<"identifier">>,
-            variations
-            =>
-            [#{variation => <<"true">>, weight => 0}, #{variation => <<"false">>, weight => 100}]
-          }
-        }
-      }
-    ],
-    state => <<"on">>,
-    variationToTargetMap => null,
-    variations
-    =>
-    [
-      #{identifier => <<"true">>, name => <<"True">>, value => <<"true">>},
-      #{identifier => <<"false">>, name => <<"False">>, value => <<"false">>}
-    ],
-    version => 4
-  }.
-
-percentage_rollout_boolean_70_30() ->
-  #{
-    defaultServe => #{variation => <<"true">>},
-    environment => <<"dev">>,
-    feature => <<"My_boolean_flag">>,
-    kind => <<"boolean">>,
-    offVariation => <<"false">>,
-    prerequisites => [],
-    project => <<"erlangsdktest">>,
-    rules
-    =>
-    [
-      #{
-        clauses
-        =>
-        [
-          #{
-            attribute => <<>>,
-            id => <<"d20dbdea-2b38-4343-b6fc-6fb09d41674d">>,
-            negate => false,
-            op => <<"segmentMatch">>,
-            values => [<<"target_group_1">>]
-          }
-        ],
-        priority => 0,
-        ruleId => <<"fbd0df98-2867-496d-8443-e3578236623d">>,
-        serve
-        =>
-        #{
-          distribution
-          =>
-          #{
-            bucketBy => <<"identifier">>,
-            variations
-            =>
-            [#{variation => <<"true">>, weight => 70}, #{variation => <<"false">>, weight => 30}]
+            [#{variation => <<"true">>, weight => Weight1}, #{variation => <<"false">>, weight => Weight2}]
           }
         }
       }

--- a/test/cfclient_evaluator_test_data.erl
+++ b/test/cfclient_evaluator_test_data.erl
@@ -27,7 +27,7 @@
   prerequisite_matches_flag_1/0,
   prerequisite_matches_flag_2/0,
   prerequisite_matches_flag_3/0
-  , generate_targets/2, percentage_rollout_boolean/2]).
+  , generate_targets/2, percentage_rollout_boolean/2, percentage_rollout_multi_variate/3]).
 
 boolean_flag_off() ->
   #{
@@ -935,6 +935,58 @@ percentage_rollout_boolean(Weight1, Weight2) ->
             variations
             =>
             [#{variation => <<"true">>, weight => Weight1}, #{variation => <<"false">>, weight => Weight2}]
+          }
+        }
+      }
+    ],
+    state => <<"on">>,
+    variationToTargetMap => null,
+    variations
+    =>
+    [
+      #{identifier => <<"true">>, name => <<"True">>, value => <<"true">>},
+      #{identifier => <<"false">>, name => <<"False">>, value => <<"false">>}
+    ],
+    version => 4
+  }.
+
+percentage_rollout_multi_variate(Weight1, Weight2, Weight3) ->
+  #{
+    defaultServe => #{variation => <<"true">>},
+    environment => <<"dev">>,
+    feature => <<"My_string_flag">>,
+    kind => <<"string">>,
+    offVariation => <<"off">>,
+    prerequisites => [],
+    project => <<"erlangsdktest">>,
+    rules
+    =>
+    [
+      #{
+        clauses
+        =>
+        [
+          #{
+            attribute => <<>>,
+            id => <<"d20dbdea-2b38-4343-b6fc-6fb09d41674d">>,
+            negate => false,
+            op => <<"segmentMatch">>,
+            values => [<<"target_group_1">>]
+          }
+        ],
+        priority => 0,
+        ruleId => <<"fbd0df98-2867-496d-8443-e3578236623d">>,
+        serve
+        =>
+        #{
+          distribution
+          =>
+          #{
+            bucketBy => <<"identifier">>,
+            variations
+            =>
+            [#{variation => <<"variation1">>, weight => Weight1}, #{variation => <<"variation1">>, weight => Weight2},
+              #{variation => <<"variation3">>, weight => Weight3}]
           }
         }
       }

--- a/test/cfclient_evaluator_test_data.erl
+++ b/test/cfclient_evaluator_test_data.erl
@@ -4,35 +4,33 @@
 
 %% API
 
--export(
-  [
-    json_flag_only_groups/0,
-    target_group_for_percentage_rollout/0,
-    target_group/0,
-    json_flag_targets_and_groups/0,
-    json_flag_no_targets_or_groups/0,
-    json_flag_only_targets/0,
-    json_flag_off/0,
-    number_flag_only_groups/0,
-    number_flag_no_targets_or_groups/0,
-    number_flag_only_targets/0,
-    number_flag_off/0,
-    string_flag_target_and_groups/0,
-    string_flag_no_targets_or_groups/0,
-    string_flag_off/0,
-    boolean_flag_single_target/0,
-    boolean_flag_group_only/0,
-    boolean_flag_no_targets_or_groups/0,
-    boolean_flag_off/0,
-    percentage_rollout_boolean_50_50/0,
-    percentage_rollout_boolean_100_true/0,
-    percentage_rollout_boolean_100_false/0,
-    flag_with_three_prerequisites/0,
-    prerequisite_matches_flag_1/0,
-    prerequisite_matches_flag_2/0,
-    prerequisite_matches_flag_3/0
-  ]
-).
+-export([
+  json_flag_only_groups/0,
+  target_group_for_percentage_rollout/0,
+  target_group/0,
+  json_flag_targets_and_groups/0,
+  json_flag_no_targets_or_groups/0,
+  json_flag_only_targets/0,
+  json_flag_off/0,
+  number_flag_only_groups/0,
+  number_flag_no_targets_or_groups/0,
+  number_flag_only_targets/0,
+  number_flag_off/0,
+  string_flag_target_and_groups/0,
+  string_flag_no_targets_or_groups/0,
+  string_flag_off/0,
+  boolean_flag_single_target/0,
+  boolean_flag_group_only/0,
+  boolean_flag_no_targets_or_groups/0,
+  boolean_flag_off/0,
+  percentage_rollout_boolean_50_50/0,
+  percentage_rollout_boolean_100_true/0,
+  percentage_rollout_boolean_100_false/0,
+  flag_with_three_prerequisites/0,
+  prerequisite_matches_flag_1/0,
+  prerequisite_matches_flag_2/0,
+  prerequisite_matches_flag_3/0
+  , generate_targets/2]).
 
 boolean_flag_off() ->
   #{
@@ -858,8 +856,20 @@ target_group() ->
     version => 19
   }.
 
+generate_targets(Start, End) ->
+  [
+    #{
+      account => <<>>,
+      environment => <<>>,
+      identifier => list_to_binary("target" ++ integer_to_list(N)),
+      name => <<"target_test">>,
+      org => <<>>,
+      project => <<>>
+    } || N <- lists:seq(Start, End)
+  ].
+
 target_group_for_percentage_rollout() ->
-  #{
+   #{
     environment => <<"dev">>,
     excluded
     =>
@@ -876,170 +886,18 @@ target_group_for_percentage_rollout() ->
     identifier => <<"target_group_1">>,
     included
     =>
-    [
+%%    generate_targets(0, 5),
+    [],
+    name => <<"target_group_1">>,
+    rules => [
       #{
-        account => <<>>,
-        environment => <<>>,
-        identifier => <<"target1">>,
-        name => <<"target_1">>,
-        org => <<>>,
-        project => <<>>
-      },
-      #{
-        account => <<>>,
-        environment => <<>>,
-        identifier => <<"target2">>,
-        name => <<"target_2">>,
-        org => <<>>,
-        project => <<>>
-      },
-      #{
-        account => <<>>,
-        environment => <<>>,
-        identifier => <<"target3">>,
-        name => <<"target_3">>,
-        org => <<>>,
-        project => <<>>
-      },
-      #{
-        account => <<>>,
-        environment => <<>>,
-        identifier => <<"target4">>,
-        name => <<"target_4">>,
-        org => <<>>,
-        project => <<>>
-      },
-      #{
-        account => <<>>,
-        environment => <<>>,
-        identifier => <<"target5">>,
-        name => <<"target_test">>,
-        org => <<>>,
-        project => <<>>
-      },
-      #{
-        account => <<>>,
-        environment => <<>>,
-        identifier => <<"target6">>,
-        name => <<"target_test">>,
-        org => <<>>,
-        project => <<>>
-      },
-      #{
-        account => <<>>,
-        environment => <<>>,
-        identifier => <<"target7">>,
-        name => <<"target_test">>,
-        org => <<>>,
-        project => <<>>
-      },
-      #{
-        account => <<>>,
-        environment => <<>>,
-        identifier => <<"target8">>,
-        name => <<"target_test">>,
-        org => <<>>,
-        project => <<>>
-      },
-      #{
-        account => <<>>,
-        environment => <<>>,
-        identifier => <<"target9">>,
-        name => <<"target_test">>,
-        org => <<>>,
-        project => <<>>
-      },
-      #{
-        account => <<>>,
-        environment => <<>>,
-        identifier => <<"target10">>,
-        name => <<"target_test">>,
-        org => <<>>,
-        project => <<>>
-      },
-      #{
-        account => <<>>,
-        environment => <<>>,
-        identifier => <<"target11">>,
-        name => <<"target_test">>,
-        org => <<>>,
-        project => <<>>
-      },
-      #{
-        account => <<>>,
-        environment => <<>>,
-        identifier => <<"target12">>,
-        name => <<"target_test">>,
-        org => <<>>,
-        project => <<>>
-      },
-      #{
-        account => <<>>,
-        environment => <<>>,
-        identifier => <<"target13">>,
-        name => <<"target_test">>,
-        org => <<>>,
-        project => <<>>
-      },
-      #{
-        account => <<>>,
-        environment => <<>>,
-        identifier => <<"target14">>,
-        name => <<"target_test">>,
-        org => <<>>,
-        project => <<>>
-      },
-      #{
-        account => <<>>,
-        environment => <<>>,
-        identifier => <<"target15">>,
-        name => <<"target_test">>,
-        org => <<>>,
-        project => <<>>
-      },
-      #{
-        account => <<>>,
-        environment => <<>>,
-        identifier => <<"target16">>,
-        name => <<"target_test">>,
-        org => <<>>,
-        project => <<>>
-      },
-      #{
-        account => <<>>,
-        environment => <<>>,
-        identifier => <<"target17">>,
-        name => <<"target_test">>,
-        org => <<>>,
-        project => <<>>
-      },
-      #{
-        account => <<>>,
-        environment => <<>>,
-        identifier => <<"target18">>,
-        name => <<"target_test">>,
-        org => <<>>,
-        project => <<>>
-      },
-      #{
-        account => <<>>,
-        environment => <<>>,
-        identifier => <<"target19">>,
-        name => <<"target_test">>,
-        org => <<>>,
-        project => <<>>
-      },
-      #{
-        account => <<>>,
-        environment => <<>>,
-        identifier => <<"target20">>,
-        name => <<"target_test">>,
-        org => <<>>,
-        project => <<>>
+        attribute => <<"identifier">>,
+        id => <<"7f779368-036c-40e3-a8b7-8b69bd809f39">>,
+        negate => false,
+        op => <<"starts_with">>,
+        values => [<<"target">>]
       }
     ],
-    name => <<"target_group_1">>,
-    rules => [],
     version => 19
   }.
 

--- a/test/cfclient_evaluator_tests.erl
+++ b/test/cfclient_evaluator_tests.erl
@@ -1759,7 +1759,7 @@ percentage_rollout() ->
             )
         end,
         %% For low target counts, in this case 20, a split like this is expected.
-        ?_assertEqual({12, 8}, do_variation_20_times({0, 0}, 0))
+        {timeout, 30, ?_assertEqual({100000, 100000}, do_variation_200k_times({0, 0}, 0))}
       },
       {
         "100/0",
@@ -1778,7 +1778,7 @@ percentage_rollout() ->
               end
             )
         end,
-        ?_assertEqual({20, 0}, do_variation_20_times({0, 0}, 0))
+        ?_assertEqual({20, 0}, do_variation_200k_times({0, 0}, 0))
       },
       {
         "0/100",
@@ -1797,15 +1797,15 @@ percentage_rollout() ->
               end
             )
         end,
-        ?_assertEqual({0, 20}, do_variation_20_times({0, 0}, 0))
+        ?_assertEqual({0, 20}, do_variation_200k_times({0, 0}, 0))
       }
     ]
   }.
 
 
-do_variation_20_times({TrueCounter, FalseCounter}, 20) -> {TrueCounter, FalseCounter};
+do_variation_200k_times({TrueCounter, FalseCounter}, 200000) -> {TrueCounter, FalseCounter};
 
-do_variation_20_times({TrueCounter, FalseCounter}, AccuIn) ->
+do_variation_200k_times({TrueCounter, FalseCounter}, AccuIn) ->
   Counter = AccuIn + 1,
   TargetIdentifierNumber = integer_to_binary(Counter),
   DynamicTarget =
@@ -1816,10 +1816,10 @@ do_variation_20_times({TrueCounter, FalseCounter}, AccuIn) ->
     },
   case cfclient_evaluator:bool_variation(<<"My_boolean_flag">>, DynamicTarget, config()) of
     {ok, _VariationIdentifier, true} ->
-      do_variation_20_times({TrueCounter + 1, FalseCounter + 0}, Counter);
+      do_variation_200k_times({TrueCounter + 1, FalseCounter + 0}, Counter);
 
     {ok, _VariationIdentifier, false} ->
-      do_variation_20_times({TrueCounter + 0, FalseCounter + 1}, Counter)
+      do_variation_200k_times({TrueCounter + 0, FalseCounter + 1}, Counter)
   end.
 
 

--- a/test/cfclient_evaluator_tests.erl
+++ b/test/cfclient_evaluator_tests.erl
@@ -1859,7 +1859,7 @@ percentage_rollout_multivariate_string_flag() ->
             [
               {
                 timeout,
-                30,
+                100,
                 ?_assertEqual({68024, 66092, 65884}, do_string_variation_200k_times({0, 0, 0}, 0))
               }
             ]
@@ -1887,7 +1887,7 @@ percentage_rollout_multivariate_string_flag() ->
             [
               {
                 timeout,
-                30,
+                100,
                 ?_assertEqual({200000, 0, 0}, do_string_variation_200k_times({0, 0, 0}, 0))
               }
             ]
@@ -1915,7 +1915,7 @@ percentage_rollout_multivariate_string_flag() ->
             [
               {
                 timeout,
-                30,
+                100,
                 ?_assertEqual({0, 0, 200000}, do_string_variation_200k_times({0, 0, 0}, 0))
               }
             ]
@@ -1943,7 +1943,7 @@ percentage_rollout_multivariate_string_flag() ->
             [
               {
                 timeout,
-                30,
+                100,
                 ?_assertEqual({0, 99992, 100008}, do_string_variation_200k_times({0, 0, 0}, 0))
               }
             ]
@@ -1971,7 +1971,7 @@ percentage_rollout_multivariate_string_flag() ->
             [
               {
                 timeout,
-                30,
+                100,
                 ?_assertEqual({160095, 19903, 20002}, do_string_variation_200k_times({0, 0, 0}, 0))
               }
             ]

--- a/test/cfclient_evaluator_tests.erl
+++ b/test/cfclient_evaluator_tests.erl
@@ -1972,7 +1972,7 @@ percentage_rollout_multivariate_string_flag() ->
               {
                 timeout,
                 30,
-                ?_assertEqual({0, 99992, 100008}, do_string_variation_200k_times({0, 0, 0}, 0))
+                ?_assertEqual({160095, 19903, 20002}, do_string_variation_200k_times({0, 0, 0}, 0))
               }
             ]
         end

--- a/test/cfclient_evaluator_tests.erl
+++ b/test/cfclient_evaluator_tests.erl
@@ -1754,7 +1754,9 @@ percentage_rollout() ->
                   cfclient_evaluator_test_data:target_group_for_percentage_rollout();
 
                 (_, <<"flags/My_boolean_flag">>) ->
-                  cfclient_evaluator_test_data:percentage_rollout_boolean(50, 50),
+                  cfclient_evaluator_test_data:percentage_rollout_boolean(50, 50);
+
+                (_, <<"flags/My_string_flag">>) ->
                   cfclient_evaluator_test_data:percentage_rollout_multi_variate(34, 33, 33)
               end
             )
@@ -1762,69 +1764,69 @@ percentage_rollout() ->
         %% For low target counts, in this case 20, a split like this is expected.
         {timeout, 30, ?_assertEqual({99992, 100008}, do_variation_200k_times({0, 0}, 0, fun(DynamicTarget) -> cfclient_evaluator:bool_variation(<<"My_boolean_flag">>, DynamicTarget, config()) end))},
         {timeout, 30, ?_assertEqual({2, 2, 2}, do_variation_200k_times({0, 0}, 0, fun(DynamicTarget) -> cfclient_evaluator:string_variation(<<"My_string_flag">>, DynamicTarget, config()) end))}
-      },
-      {
-        "100/0 boolean and 100/0/0 multivariate",
-        setup,
-        fun
-          () ->
-            meck:expect(
-              cfclient_ets,
-              get,
-              fun
-                (_, <<"segments/target_group_1">>) ->
-                  cfclient_evaluator_test_data:target_group_for_percentage_rollout();
-
-                (_, <<"flags/My_boolean_flag">>) ->
-                  cfclient_evaluator_test_data:percentage_rollout_boolean(100, 0),
-                  cfclient_evaluator_test_data:percentage_rollout_multi_variate(100, 0, 0)
-              end
-            )
-        end,
-        {timeout, 30, ?_assertEqual({200000, 0}, do_variation_200k_times({0, 0}, 0, fun(DynamicTarget) -> cfclient_evaluator:bool_variation(<<"My_boolean_flag">>, DynamicTarget, config()) end))},
-        {timeout, 30, ?_assertEqual({2, 2, 2}, do_variation_200k_times({0, 0}, 0, fun(DynamicTarget) -> cfclient_evaluator:string_variation(<<"My_string_flag">>, DynamicTarget, config()) end))}
-
-      },
-      {
-        "0/100",
-        setup,
-        fun
-          () ->
-            meck:expect(
-              cfclient_ets,
-              get,
-              fun
-                (_, <<"segments/target_group_1">>) ->
-                  cfclient_evaluator_test_data:target_group_for_percentage_rollout();
-
-                (_, <<"flags/My_boolean_flag">>) ->
-                  cfclient_evaluator_test_data:percentage_rollout_boolean(0, 100)
-              end
-            )
-        end,
-        {timeout, 30, ?_assertEqual({0, 200000}, do_variation_200k_times({0, 0}, 0, fun(DynamicTarget) -> cfclient_evaluator:bool_variation(<<"My_boolean_flag">>, DynamicTarget, config()) end))},
-        {timeout, 30, ?_assertEqual({2, 2, 2}, do_variation_200k_times({0, 0}, 0, fun(DynamicTarget) -> cfclient_evaluator:string_variation(<<"My_string_flag">>, DynamicTarget, config()) end))}
-      },
-      {
-        "70/30",
-        setup,
-        fun
-          () ->
-            meck:expect(
-              cfclient_ets,
-              get,
-              fun
-                (_, <<"segments/target_group_1">>) ->
-                  cfclient_evaluator_test_data:target_group_for_percentage_rollout();
-
-                (_, <<"flags/My_boolean_flag">>) ->
-                  cfclient_evaluator_test_data:percentage_rollout_boolean(70, 30)
-              end
-            )
-        end,
-        {timeout, 30, ?_assertEqual({140098, 59902}, do_variation_200k_times({0, 0}, 0, fun(DynamicTarget) -> cfclient_evaluator:bool_variation(<<"My_boolean_flag">>, DynamicTarget, config()) end))},
-        {timeout, 30, ?_assertEqual({2, 2, 2}, do_variation_200k_times({0, 0}, 0, fun(DynamicTarget) -> cfclient_evaluator:string_variation(<<"My_string_flag">>, DynamicTarget, config()) end))}
       }
+%%      {
+%%        "100/0 boolean and 100/0/0 multivariate",
+%%        setup,
+%%        fun
+%%          () ->
+%%            meck:expect(
+%%              cfclient_ets,
+%%              get,
+%%              fun
+%%                (_, <<"segments/target_group_1">>) ->
+%%                  cfclient_evaluator_test_data:target_group_for_percentage_rollout();
+%%
+%%                (_, <<"flags/My_boolean_flag">>) ->
+%%                  cfclient_evaluator_test_data:percentage_rollout_boolean(100, 0),
+%%                  cfclient_evaluator_test_data:percentage_rollout_multi_variate(100, 0, 0)
+%%              end
+%%            )
+%%        end,
+%%        {timeout, 30, ?_assertEqual({200000, 0}, do_variation_200k_times({0, 0}, 0, fun(DynamicTarget) -> cfclient_evaluator:bool_variation(<<"My_boolean_flag">>, DynamicTarget, config()) end))},
+%%        {timeout, 30, ?_assertEqual({2, 2, 2}, do_variation_200k_times({0, 0}, 0, fun(DynamicTarget) -> cfclient_evaluator:string_variation(<<"My_string_flag">>, DynamicTarget, config()) end))}
+%%
+%%      },
+%%      {
+%%        "0/100",
+%%        setup,
+%%        fun
+%%          () ->
+%%            meck:expect(
+%%              cfclient_ets,
+%%              get,
+%%              fun
+%%                (_, <<"segments/target_group_1">>) ->
+%%                  cfclient_evaluator_test_data:target_group_for_percentage_rollout();
+%%
+%%                (_, <<"flags/My_boolean_flag">>) ->
+%%                  cfclient_evaluator_test_data:percentage_rollout_boolean(0, 100)
+%%              end
+%%            )
+%%        end,
+%%        {timeout, 30, ?_assertEqual({0, 200000}, do_variation_200k_times({0, 0}, 0, fun(DynamicTarget) -> cfclient_evaluator:bool_variation(<<"My_boolean_flag">>, DynamicTarget, config()) end))},
+%%        {timeout, 30, ?_assertEqual({2, 2, 2}, do_variation_200k_times({0, 0}, 0, fun(DynamicTarget) -> cfclient_evaluator:string_variation(<<"My_string_flag">>, DynamicTarget, config()) end))}
+%%      },
+%%      {
+%%        "70/30",
+%%        setup,
+%%        fun
+%%          () ->
+%%            meck:expect(
+%%              cfclient_ets,
+%%              get,
+%%              fun
+%%                (_, <<"segments/target_group_1">>) ->
+%%                  cfclient_evaluator_test_data:target_group_for_percentage_rollout();
+%%
+%%                (_, <<"flags/My_boolean_flag">>) ->
+%%                  cfclient_evaluator_test_data:percentage_rollout_boolean(70, 30)
+%%              end
+%%            )
+%%        end,
+%%        {timeout, 30, ?_assertEqual({140098, 59902}, do_variation_200k_times({0, 0}, 0, fun(DynamicTarget) -> cfclient_evaluator:bool_variation(<<"My_boolean_flag">>, DynamicTarget, config()) end))},
+%%        {timeout, 30, ?_assertEqual({2, 2, 2}, do_variation_200k_times({0, 0}, 0, fun(DynamicTarget) -> cfclient_evaluator:string_variation(<<"My_string_flag">>, DynamicTarget, config()) end))}
+%%      }
     ]
   }.
 

--- a/test/cfclient_evaluator_tests.erl
+++ b/test/cfclient_evaluator_tests.erl
@@ -33,6 +33,7 @@ top_test_() ->
       {generator, fun variations_number/0},
       {generator, fun variations_json/0},
       {generator, fun percentage_rollout_boolean_flag/0},
+      {generator, fun percentage_rollout_multivariate_string_flag/0},
       {generator, fun search_prerequisites/0},
       {generator, fun check_prerequisite/0}
     ]
@@ -1859,7 +1860,6 @@ percentage_rollout_multivariate_string_flag() ->
           [
             {timeout, 30, ?_assertEqual({68024, 66092, 65884}, do_string_variation_200k_times({0, 0, 0}, 0))}          ]
         end
-
       },
       {
         "100/0/0",
@@ -1921,9 +1921,11 @@ percentage_rollout_multivariate_string_flag() ->
                   cfclient_evaluator_test_data:percentage_rollout_multi_variate(0, 50, 50)
               end
             )
+        end,
+        fun(_) ->
+          [
+            {timeout, 30, ?_assertEqual({0, 99992, 100008}, do_string_variation_200k_times({0, 0, 0}, 0))}          ]
         end
-%%        {timeout, 30, ?_assertEqual({140098, 59902}, do_variation_200k_times({0, 0}, 0, fun(DynamicTarget) -> cfclient_evaluator:bool_variation(<<"My_boolean_flag">>, DynamicTarget, config()) end))},
-%%        {timeout, 30, ?_assertEqual({2, 2, 2}, do_variation_200k_times({0, 0}, 0, fun(DynamicTarget) -> cfclient_evaluator:string_variation(<<"My_string_flag">>, DynamicTarget, config()) end))}
       }
     ]
   }.

--- a/test/cfclient_evaluator_tests.erl
+++ b/test/cfclient_evaluator_tests.erl
@@ -1759,11 +1759,10 @@ percentage_rollout_boolean_flag() ->
               end
             )
         end,
-        fun(_) ->
-          [
-            {timeout, 30, ?_assertEqual({99992, 100008}, do_bool_variation_200k_times({0, 0}, 0))}]
+        fun
+          (_) ->
+            [{timeout, 30, ?_assertEqual({99992, 100008}, do_bool_variation_200k_times({0, 0}, 0))}]
         end
-
       },
       {
         "100/0",
@@ -1782,10 +1781,10 @@ percentage_rollout_boolean_flag() ->
               end
             )
         end,
-    fun(_) ->
-      [
-        {timeout, 30, ?_assertEqual({200000, 0}, do_bool_variation_200k_times({0, 0}, 0))}]
-    end
+        fun
+          (_) ->
+            [{timeout, 30, ?_assertEqual({200000, 0}, do_bool_variation_200k_times({0, 0}, 0))}]
+        end
       },
       {
         "0/100",
@@ -1801,13 +1800,12 @@ percentage_rollout_boolean_flag() ->
 
                 (_, <<"flags/My_boolean_flag">>) ->
                   cfclient_evaluator_test_data:percentage_rollout_boolean(0, 100)
-
               end
             )
         end,
-        fun(_) ->
-          [
-            {timeout, 30, ?_assertEqual({0, 200000}, do_bool_variation_200k_times({0, 0}, 0))}]
+        fun
+          (_) ->
+            [{timeout, 30, ?_assertEqual({0, 200000}, do_bool_variation_200k_times({0, 0}, 0))}]
         end
       },
       {
@@ -1827,9 +1825,9 @@ percentage_rollout_boolean_flag() ->
               end
             )
         end,
-        fun(_) ->
-          [
-            {timeout, 30, ?_assertEqual({140098, 59902}, do_bool_variation_200k_times({0, 0}, 0))}]
+        fun
+          (_) ->
+            [{timeout, 30, ?_assertEqual({140098, 59902}, do_bool_variation_200k_times({0, 0}, 0))}]
         end
       }
     ]
@@ -1856,9 +1854,15 @@ percentage_rollout_multivariate_string_flag() ->
               end
             )
         end,
-        fun(_) ->
-          [
-            {timeout, 30, ?_assertEqual({68024, 66092, 65884}, do_string_variation_200k_times({0, 0, 0}, 0))}          ]
+        fun
+          (_) ->
+            [
+              {
+                timeout,
+                30,
+                ?_assertEqual({68024, 66092, 65884}, do_string_variation_200k_times({0, 0, 0}, 0))
+              }
+            ]
         end
       },
       {
@@ -1878,9 +1882,15 @@ percentage_rollout_multivariate_string_flag() ->
               end
             )
         end,
-        fun(_) ->
-          [
-            {timeout, 30, ?_assertEqual({200000, 0, 0}, do_string_variation_200k_times({0, 0, 0}, 0))}          ]
+        fun
+          (_) ->
+            [
+              {
+                timeout,
+                30,
+                ?_assertEqual({200000, 0, 0}, do_string_variation_200k_times({0, 0, 0}, 0))
+              }
+            ]
         end
       },
       {
@@ -1900,9 +1910,15 @@ percentage_rollout_multivariate_string_flag() ->
               end
             )
         end,
-        fun(_) ->
-          [
-            {timeout, 30, ?_assertEqual({0, 0, 200000}, do_string_variation_200k_times({0, 0, 0}, 0))}          ]
+        fun
+          (_) ->
+            [
+              {
+                timeout,
+                30,
+                ?_assertEqual({0, 0, 200000}, do_string_variation_200k_times({0, 0, 0}, 0))
+              }
+            ]
         end
       },
       {
@@ -1922,13 +1938,48 @@ percentage_rollout_multivariate_string_flag() ->
               end
             )
         end,
-        fun(_) ->
-          [
-            {timeout, 30, ?_assertEqual({0, 99992, 100008}, do_string_variation_200k_times({0, 0, 0}, 0))}          ]
+        fun
+          (_) ->
+            [
+              {
+                timeout,
+                30,
+                ?_assertEqual({0, 99992, 100008}, do_string_variation_200k_times({0, 0, 0}, 0))
+              }
+            ]
+        end
+      },
+      {
+        "80/10/10",
+        setup,
+        fun
+          () ->
+            meck:expect(
+              cfclient_ets,
+              get,
+              fun
+                (_, <<"segments/target_group_1">>) ->
+                  cfclient_evaluator_test_data:target_group_for_percentage_rollout();
+
+                (_, <<"flags/My_string_flag">>) ->
+                  cfclient_evaluator_test_data:percentage_rollout_multi_variate(80, 10, 10)
+              end
+            )
+        end,
+        fun
+          (_) ->
+            [
+              {
+                timeout,
+                30,
+                ?_assertEqual({0, 99992, 100008}, do_string_variation_200k_times({0, 0, 0}, 0))
+              }
+            ]
         end
       }
     ]
   }.
+
 do_bool_variation_200k_times({TrueCounter, FalseCounter}, 200000) -> {TrueCounter, FalseCounter};
 
 do_bool_variation_200k_times({TrueCounter, FalseCounter}, AccuIn) ->
@@ -1940,7 +1991,7 @@ do_bool_variation_200k_times({TrueCounter, FalseCounter}, AccuIn) ->
       name => <<"targetname", TargetIdentifierNumber/binary>>,
       anonymous => <<"">>
     },
-%%  case cfclient_evaluator:bool_variation(<<"My_boolean_flag">>, DynamicTarget, config()) of
+  %%  case cfclient_evaluator:bool_variation(<<"My_boolean_flag">>, DynamicTarget, config()) of
   case cfclient_evaluator:bool_variation(<<"My_boolean_flag">>, DynamicTarget, config()) of
     {ok, _VariationIdentifier, true} ->
       do_bool_variation_200k_times({TrueCounter + 1, FalseCounter + 0}, Counter);
@@ -1949,7 +2000,9 @@ do_bool_variation_200k_times({TrueCounter, FalseCounter}, AccuIn) ->
       do_bool_variation_200k_times({TrueCounter + 0, FalseCounter + 1}, Counter)
   end.
 
-do_string_variation_200k_times({Variation1Counter, Variation2Counter, Variation3Counter}, 200000) -> {Variation1Counter, Variation2Counter, Variation3Counter};
+
+do_string_variation_200k_times({Variation1Counter, Variation2Counter, Variation3Counter}, 200000) ->
+  {Variation1Counter, Variation2Counter, Variation3Counter};
 
 do_string_variation_200k_times({Variation1Counter, Variation2Counter, Variation3Counter}, AccuIn) ->
   Counter = AccuIn + 1,
@@ -1960,16 +2013,25 @@ do_string_variation_200k_times({Variation1Counter, Variation2Counter, Variation3
       name => <<"targetname", TargetIdentifierNumber/binary>>,
       anonymous => <<"">>
     },
-%%  case cfclient_evaluator:bool_variation(<<"My_boolean_flag">>, DynamicTarget, config()) of
+  %%  case cfclient_evaluator:bool_variation(<<"My_boolean_flag">>, DynamicTarget, config()) of
   case cfclient_evaluator:string_variation(<<"My_string_flag">>, DynamicTarget, config()) of
     {ok, _VariationIdentifier, <<"variation1">>} ->
-      do_string_variation_200k_times({Variation1Counter + 1, Variation2Counter + 0,  Variation3Counter + 0}, Counter);
+      do_string_variation_200k_times(
+        {Variation1Counter + 1, Variation2Counter + 0, Variation3Counter + 0},
+        Counter
+      );
 
-    {ok, _VariationIdentifier,  <<"variation2">>} ->
-      do_string_variation_200k_times({Variation1Counter + 0, Variation2Counter + 1,  Variation3Counter + 0}, Counter);
+    {ok, _VariationIdentifier, <<"variation2">>} ->
+      do_string_variation_200k_times(
+        {Variation1Counter + 0, Variation2Counter + 1, Variation3Counter + 0},
+        Counter
+      );
 
-    {ok, _VariationIdentifier,  <<"variation3">>} ->
-      do_string_variation_200k_times({Variation1Counter + 0, Variation2Counter + 0,  Variation3Counter + 1}, Counter)
+    {ok, _VariationIdentifier, <<"variation3">>} ->
+      do_string_variation_200k_times(
+        {Variation1Counter + 0, Variation2Counter + 0, Variation3Counter + 1},
+        Counter
+      )
   end.
 
 

--- a/test/cfclient_evaluator_tests.erl
+++ b/test/cfclient_evaluator_tests.erl
@@ -1759,7 +1759,7 @@ percentage_rollout() ->
             )
         end,
         %% For low target counts, in this case 20, a split like this is expected.
-        {timeout, 30, ?_assertEqual({100000, 100000}, do_variation_200k_times({0, 0}, 0))}
+        {timeout, 30, ?_assertEqual({99992, 100008}, do_variation_200k_times({0, 0}, 0))}
       },
       {
         "100/0",
@@ -1778,7 +1778,7 @@ percentage_rollout() ->
               end
             )
         end,
-        ?_assertEqual({20, 0}, do_variation_200k_times({0, 0}, 0))
+        {timeout, 30, ?_assertEqual({200000, 0}, do_variation_200k_times({0, 0}, 0))}
       },
       {
         "0/100",
@@ -1797,7 +1797,26 @@ percentage_rollout() ->
               end
             )
         end,
-        ?_assertEqual({0, 20}, do_variation_200k_times({0, 0}, 0))
+        {timeout, 30, ?_assertEqual({0, 200000}, do_variation_200k_times({0, 0}, 0))}
+      },
+      {
+        "70/30",
+        setup,
+        fun
+          () ->
+            meck:expect(
+              cfclient_ets,
+              get,
+              fun
+                (_, <<"segments/target_group_1">>) ->
+                  cfclient_evaluator_test_data:target_group_for_percentage_rollout();
+
+                (_, <<"flags/My_boolean_flag">>) ->
+                  cfclient_evaluator_test_data:percentage_rollout_boolean_70_30()
+              end
+            )
+        end,
+        {timeout, 30, ?_assertEqual({140098, 59902}, do_variation_200k_times({0, 0}, 0))}
       }
     ]
   }.

--- a/test/cfclient_evaluator_tests.erl
+++ b/test/cfclient_evaluator_tests.erl
@@ -1754,7 +1754,7 @@ percentage_rollout() ->
                   cfclient_evaluator_test_data:target_group_for_percentage_rollout();
 
                 (_, <<"flags/My_boolean_flag">>) ->
-                  cfclient_evaluator_test_data:percentage_rollout_boolean_50_50()
+                  cfclient_evaluator_test_data:percentage_rollout_boolean(50, 50)
               end
             )
         end,
@@ -1774,7 +1774,7 @@ percentage_rollout() ->
                   cfclient_evaluator_test_data:target_group_for_percentage_rollout();
 
                 (_, <<"flags/My_boolean_flag">>) ->
-                  cfclient_evaluator_test_data:percentage_rollout_boolean_100_true()
+                  cfclient_evaluator_test_data:percentage_rollout_boolean(100, 0)
               end
             )
         end,
@@ -1793,7 +1793,7 @@ percentage_rollout() ->
                   cfclient_evaluator_test_data:target_group_for_percentage_rollout();
 
                 (_, <<"flags/My_boolean_flag">>) ->
-                  cfclient_evaluator_test_data:percentage_rollout_boolean_100_false()
+                  cfclient_evaluator_test_data:percentage_rollout_boolean(0, 100)
               end
             )
         end,
@@ -1812,7 +1812,7 @@ percentage_rollout() ->
                   cfclient_evaluator_test_data:target_group_for_percentage_rollout();
 
                 (_, <<"flags/My_boolean_flag">>) ->
-                  cfclient_evaluator_test_data:percentage_rollout_boolean_70_30()
+                  cfclient_evaluator_test_data:percentage_rollout_boolean(70, 30)
               end
             )
         end,

--- a/test/cfclient_evaluator_tests.erl
+++ b/test/cfclient_evaluator_tests.erl
@@ -1993,10 +1993,10 @@ do_bool_variation_200k_times({TrueCounter, FalseCounter}, AccuIn) ->
     },
   case cfclient_evaluator:bool_variation(<<"My_boolean_flag">>, DynamicTarget, config()) of
     {ok, _VariationIdentifier, true} ->
-      do_bool_variation_200k_times({TrueCounter + 1, FalseCounter + 0}, Counter);
+      do_bool_variation_200k_times({TrueCounter + 1, FalseCounter}, Counter);
 
     {ok, _VariationIdentifier, false} ->
-      do_bool_variation_200k_times({TrueCounter + 0, FalseCounter + 1}, Counter)
+      do_bool_variation_200k_times({TrueCounter, FalseCounter + 1}, Counter)
   end.
 
 
@@ -2015,19 +2015,19 @@ do_string_variation_200k_times({Variation1Counter, Variation2Counter, Variation3
   case cfclient_evaluator:string_variation(<<"My_string_flag">>, DynamicTarget, config()) of
     {ok, _VariationIdentifier, <<"variation1">>} ->
       do_string_variation_200k_times(
-        {Variation1Counter + 1, Variation2Counter + 0, Variation3Counter + 0},
+        {Variation1Counter + 1, Variation2Counter, Variation3Counter},
         Counter
       );
 
     {ok, _VariationIdentifier, <<"variation2">>} ->
       do_string_variation_200k_times(
-        {Variation1Counter + 0, Variation2Counter + 1, Variation3Counter + 0},
+        {Variation1Counter, Variation2Counter + 1, Variation3Counter},
         Counter
       );
 
     {ok, _VariationIdentifier, <<"variation3">>} ->
       do_string_variation_200k_times(
-        {Variation1Counter + 0, Variation2Counter + 0, Variation3Counter + 1},
+        {Variation1Counter, Variation2Counter, Variation3Counter + 1},
         Counter
       )
   end.

--- a/test/cfclient_evaluator_tests.erl
+++ b/test/cfclient_evaluator_tests.erl
@@ -32,7 +32,7 @@ top_test_() ->
       {generator, fun variations_string/0},
       {generator, fun variations_number/0},
       {generator, fun variations_json/0},
-      {generator, fun percentage_rollout/0},
+      {generator, fun percentage_rollout_boolean_flag/0},
       {generator, fun search_prerequisites/0},
       {generator, fun check_prerequisite/0}
     ]
@@ -1737,12 +1737,12 @@ custom_attribute_to_binary_test_() ->
     }
   ].
 
-percentage_rollout() ->
+percentage_rollout_boolean_flag() ->
   {
-    "Percentage Rollout",
+    "Percentage Rollout Boolean",
     [
       {
-        "50/50 boolean and 34/33/33",
+        "50/50",
         setup,
         fun
           () ->
@@ -1754,22 +1754,18 @@ percentage_rollout() ->
                   cfclient_evaluator_test_data:target_group_for_percentage_rollout();
 
                 (_, <<"flags/My_boolean_flag">>) ->
-                  cfclient_evaluator_test_data:percentage_rollout_boolean(50, 50);
-
-                (_, <<"flags/My_string_flag">>) ->
-                  cfclient_evaluator_test_data:percentage_rollout_multi_variate(34, 33, 33)
+                  cfclient_evaluator_test_data:percentage_rollout_boolean(50, 50)
               end
             )
         end,
         fun(_) ->
           [
-            {timeout, 30, ?_assertEqual({99992, 100008}, do_bool_variation_200k_times({0, 0}, 0))},
-            {timeout, 30, ?_assertEqual({68024, 66092, 65884}, do_string_variation_200k_times({0, 0, 0}, 0))}          ]
+            {timeout, 30, ?_assertEqual({99992, 100008}, do_bool_variation_200k_times({0, 0}, 0))}]
         end
 
-      }
+      },
       {
-        "100/0 boolean and 100/0/0 multivariate",
+        "100/0",
         setup,
         fun
           () ->
@@ -1781,14 +1777,14 @@ percentage_rollout() ->
                   cfclient_evaluator_test_data:target_group_for_percentage_rollout();
 
                 (_, <<"flags/My_boolean_flag">>) ->
-                  cfclient_evaluator_test_data:percentage_rollout_boolean(100, 0),
-                  cfclient_evaluator_test_data:percentage_rollout_multi_variate(100, 0, 0)
+                  cfclient_evaluator_test_data:percentage_rollout_boolean(100, 0)
               end
             )
         end,
-        {timeout, 30, ?_assertEqual({200000, 0}, do_variation_200k_times({0, 0}, 0, fun(DynamicTarget) -> cfclient_evaluator:bool_variation(<<"My_boolean_flag">>, DynamicTarget, config()) end))},
-        {timeout, 30, ?_assertEqual({2, 2, 2}, do_variation_200k_times({0, 0}, 0, fun(DynamicTarget) -> cfclient_evaluator:string_variation(<<"My_string_flag">>, DynamicTarget, config()) end))}
-
+    fun(_) ->
+      [
+        {timeout, 30, ?_assertEqual({200000, 0}, do_bool_variation_200k_times({0, 0}, 0))}]
+    end
       },
       {
         "0/100",
@@ -1804,11 +1800,14 @@ percentage_rollout() ->
 
                 (_, <<"flags/My_boolean_flag">>) ->
                   cfclient_evaluator_test_data:percentage_rollout_boolean(0, 100)
+
               end
             )
         end,
-        {timeout, 30, ?_assertEqual({0, 200000}, do_variation_200k_times({0, 0}, 0, fun(DynamicTarget) -> cfclient_evaluator:bool_variation(<<"My_boolean_flag">>, DynamicTarget, config()) end))},
-        {timeout, 30, ?_assertEqual({2, 2, 2}, do_variation_200k_times({0, 0}, 0, fun(DynamicTarget) -> cfclient_evaluator:string_variation(<<"My_string_flag">>, DynamicTarget, config()) end))}
+        fun(_) ->
+          [
+            {timeout, 30, ?_assertEqual({0, 200000}, do_bool_variation_200k_times({0, 0}, 0))}]
+        end
       },
       {
         "70/30",
@@ -1827,13 +1826,107 @@ percentage_rollout() ->
               end
             )
         end,
-        {timeout, 30, ?_assertEqual({140098, 59902}, do_variation_200k_times({0, 0}, 0, fun(DynamicTarget) -> cfclient_evaluator:bool_variation(<<"My_boolean_flag">>, DynamicTarget, config()) end))},
-        {timeout, 30, ?_assertEqual({2, 2, 2}, do_variation_200k_times({0, 0}, 0, fun(DynamicTarget) -> cfclient_evaluator:string_variation(<<"My_string_flag">>, DynamicTarget, config()) end))}
+        fun(_) ->
+          [
+            {timeout, 30, ?_assertEqual({140098, 59902}, do_bool_variation_200k_times({0, 0}, 0))}]
+        end
       }
     ]
   }.
 
+percentage_rollout_multivariate_string_flag() ->
+  {
+    "Percentage Rollout Multivariate String Flag",
+    [
+      {
+        "34/33/33",
+        setup,
+        fun
+          () ->
+            meck:expect(
+              cfclient_ets,
+              get,
+              fun
+                (_, <<"segments/target_group_1">>) ->
+                  cfclient_evaluator_test_data:target_group_for_percentage_rollout();
 
+                (_, <<"flags/My_string_flag">>) ->
+                  cfclient_evaluator_test_data:percentage_rollout_multi_variate(34, 33, 33)
+              end
+            )
+        end,
+        fun(_) ->
+          [
+            {timeout, 30, ?_assertEqual({68024, 66092, 65884}, do_string_variation_200k_times({0, 0, 0}, 0))}          ]
+        end
+
+      },
+      {
+        "100/0/0",
+        setup,
+        fun
+          () ->
+            meck:expect(
+              cfclient_ets,
+              get,
+              fun
+                (_, <<"segments/target_group_1">>) ->
+                  cfclient_evaluator_test_data:target_group_for_percentage_rollout();
+
+                (_, <<"flags/My_string_flag">>) ->
+                  cfclient_evaluator_test_data:percentage_rollout_multi_variate(100, 0, 0)
+              end
+            )
+        end,
+        fun(_) ->
+          [
+            {timeout, 30, ?_assertEqual({200000, 0, 0}, do_string_variation_200k_times({0, 0, 0}, 0))}          ]
+        end
+      },
+      {
+        "0/0/100",
+        setup,
+        fun
+          () ->
+            meck:expect(
+              cfclient_ets,
+              get,
+              fun
+                (_, <<"segments/target_group_1">>) ->
+                  cfclient_evaluator_test_data:target_group_for_percentage_rollout();
+
+                (_, <<"flags/My_string_flag">>) ->
+                  cfclient_evaluator_test_data:percentage_rollout_multi_variate(0, 0, 100)
+              end
+            )
+        end,
+        fun(_) ->
+          [
+            {timeout, 30, ?_assertEqual({0, 0, 200000}, do_string_variation_200k_times({0, 0, 0}, 0))}          ]
+        end
+      },
+      {
+        "0/50/50",
+        setup,
+        fun
+          () ->
+            meck:expect(
+              cfclient_ets,
+              get,
+              fun
+                (_, <<"segments/target_group_1">>) ->
+                  cfclient_evaluator_test_data:target_group_for_percentage_rollout();
+
+                (_, <<"flags/My_string_flag">>) ->
+                  cfclient_evaluator_test_data:percentage_rollout_multi_variate(0, 50, 50)
+              end
+            )
+        end
+%%        {timeout, 30, ?_assertEqual({140098, 59902}, do_variation_200k_times({0, 0}, 0, fun(DynamicTarget) -> cfclient_evaluator:bool_variation(<<"My_boolean_flag">>, DynamicTarget, config()) end))},
+%%        {timeout, 30, ?_assertEqual({2, 2, 2}, do_variation_200k_times({0, 0}, 0, fun(DynamicTarget) -> cfclient_evaluator:string_variation(<<"My_string_flag">>, DynamicTarget, config()) end))}
+      }
+    ]
+  }.
 do_bool_variation_200k_times({TrueCounter, FalseCounter}, 200000) -> {TrueCounter, FalseCounter};
 
 do_bool_variation_200k_times({TrueCounter, FalseCounter}, AccuIn) ->

--- a/test/cfclient_evaluator_tests.erl
+++ b/test/cfclient_evaluator_tests.erl
@@ -1761,7 +1761,7 @@ percentage_rollout_boolean_flag() ->
         end,
         fun
           (_) ->
-            [{timeout, 30, ?_assertEqual({99992, 100008}, do_bool_variation_200k_times({0, 0}, 0))}]
+            [{timeout, 100, ?_assertEqual({99992, 100008}, do_bool_variation_200k_times({0, 0}, 0))}]
         end
       },
       {
@@ -1783,7 +1783,7 @@ percentage_rollout_boolean_flag() ->
         end,
         fun
           (_) ->
-            [{timeout, 30, ?_assertEqual({200000, 0}, do_bool_variation_200k_times({0, 0}, 0))}]
+            [{timeout, 100, ?_assertEqual({200000, 0}, do_bool_variation_200k_times({0, 0}, 0))}]
         end
       },
       {
@@ -1805,7 +1805,7 @@ percentage_rollout_boolean_flag() ->
         end,
         fun
           (_) ->
-            [{timeout, 30, ?_assertEqual({0, 200000}, do_bool_variation_200k_times({0, 0}, 0))}]
+            [{timeout, 100, ?_assertEqual({0, 200000}, do_bool_variation_200k_times({0, 0}, 0))}]
         end
       },
       {
@@ -1827,7 +1827,7 @@ percentage_rollout_boolean_flag() ->
         end,
         fun
           (_) ->
-            [{timeout, 30, ?_assertEqual({140098, 59902}, do_bool_variation_200k_times({0, 0}, 0))}]
+            [{timeout, 100, ?_assertEqual({140098, 59902}, do_bool_variation_200k_times({0, 0}, 0))}]
         end
       }
     ]

--- a/test/cfclient_evaluator_tests.erl
+++ b/test/cfclient_evaluator_tests.erl
@@ -1761,79 +1761,82 @@ percentage_rollout() ->
               end
             )
         end,
-        %% For low target counts, in this case 20, a split like this is expected.
-        {timeout, 30, ?_assertEqual({99992, 100008}, do_variation_200k_times({0, 0}, 0, fun(DynamicTarget) -> cfclient_evaluator:bool_variation(<<"My_boolean_flag">>, DynamicTarget, config()) end))},
+        fun(_) ->
+          [
+            {timeout, 30, ?_assertEqual({99992, 100008}, do_bool_variation_200k_times({0, 0}, 0))},
+            {timeout, 30, ?_assertEqual({68024, 66092, 65884}, do_string_variation_200k_times({0, 0, 0}, 0))}          ]
+        end
+
+      }
+      {
+        "100/0 boolean and 100/0/0 multivariate",
+        setup,
+        fun
+          () ->
+            meck:expect(
+              cfclient_ets,
+              get,
+              fun
+                (_, <<"segments/target_group_1">>) ->
+                  cfclient_evaluator_test_data:target_group_for_percentage_rollout();
+
+                (_, <<"flags/My_boolean_flag">>) ->
+                  cfclient_evaluator_test_data:percentage_rollout_boolean(100, 0),
+                  cfclient_evaluator_test_data:percentage_rollout_multi_variate(100, 0, 0)
+              end
+            )
+        end,
+        {timeout, 30, ?_assertEqual({200000, 0}, do_variation_200k_times({0, 0}, 0, fun(DynamicTarget) -> cfclient_evaluator:bool_variation(<<"My_boolean_flag">>, DynamicTarget, config()) end))},
+        {timeout, 30, ?_assertEqual({2, 2, 2}, do_variation_200k_times({0, 0}, 0, fun(DynamicTarget) -> cfclient_evaluator:string_variation(<<"My_string_flag">>, DynamicTarget, config()) end))}
+
+      },
+      {
+        "0/100",
+        setup,
+        fun
+          () ->
+            meck:expect(
+              cfclient_ets,
+              get,
+              fun
+                (_, <<"segments/target_group_1">>) ->
+                  cfclient_evaluator_test_data:target_group_for_percentage_rollout();
+
+                (_, <<"flags/My_boolean_flag">>) ->
+                  cfclient_evaluator_test_data:percentage_rollout_boolean(0, 100)
+              end
+            )
+        end,
+        {timeout, 30, ?_assertEqual({0, 200000}, do_variation_200k_times({0, 0}, 0, fun(DynamicTarget) -> cfclient_evaluator:bool_variation(<<"My_boolean_flag">>, DynamicTarget, config()) end))},
+        {timeout, 30, ?_assertEqual({2, 2, 2}, do_variation_200k_times({0, 0}, 0, fun(DynamicTarget) -> cfclient_evaluator:string_variation(<<"My_string_flag">>, DynamicTarget, config()) end))}
+      },
+      {
+        "70/30",
+        setup,
+        fun
+          () ->
+            meck:expect(
+              cfclient_ets,
+              get,
+              fun
+                (_, <<"segments/target_group_1">>) ->
+                  cfclient_evaluator_test_data:target_group_for_percentage_rollout();
+
+                (_, <<"flags/My_boolean_flag">>) ->
+                  cfclient_evaluator_test_data:percentage_rollout_boolean(70, 30)
+              end
+            )
+        end,
+        {timeout, 30, ?_assertEqual({140098, 59902}, do_variation_200k_times({0, 0}, 0, fun(DynamicTarget) -> cfclient_evaluator:bool_variation(<<"My_boolean_flag">>, DynamicTarget, config()) end))},
         {timeout, 30, ?_assertEqual({2, 2, 2}, do_variation_200k_times({0, 0}, 0, fun(DynamicTarget) -> cfclient_evaluator:string_variation(<<"My_string_flag">>, DynamicTarget, config()) end))}
       }
-%%      {
-%%        "100/0 boolean and 100/0/0 multivariate",
-%%        setup,
-%%        fun
-%%          () ->
-%%            meck:expect(
-%%              cfclient_ets,
-%%              get,
-%%              fun
-%%                (_, <<"segments/target_group_1">>) ->
-%%                  cfclient_evaluator_test_data:target_group_for_percentage_rollout();
-%%
-%%                (_, <<"flags/My_boolean_flag">>) ->
-%%                  cfclient_evaluator_test_data:percentage_rollout_boolean(100, 0),
-%%                  cfclient_evaluator_test_data:percentage_rollout_multi_variate(100, 0, 0)
-%%              end
-%%            )
-%%        end,
-%%        {timeout, 30, ?_assertEqual({200000, 0}, do_variation_200k_times({0, 0}, 0, fun(DynamicTarget) -> cfclient_evaluator:bool_variation(<<"My_boolean_flag">>, DynamicTarget, config()) end))},
-%%        {timeout, 30, ?_assertEqual({2, 2, 2}, do_variation_200k_times({0, 0}, 0, fun(DynamicTarget) -> cfclient_evaluator:string_variation(<<"My_string_flag">>, DynamicTarget, config()) end))}
-%%
-%%      },
-%%      {
-%%        "0/100",
-%%        setup,
-%%        fun
-%%          () ->
-%%            meck:expect(
-%%              cfclient_ets,
-%%              get,
-%%              fun
-%%                (_, <<"segments/target_group_1">>) ->
-%%                  cfclient_evaluator_test_data:target_group_for_percentage_rollout();
-%%
-%%                (_, <<"flags/My_boolean_flag">>) ->
-%%                  cfclient_evaluator_test_data:percentage_rollout_boolean(0, 100)
-%%              end
-%%            )
-%%        end,
-%%        {timeout, 30, ?_assertEqual({0, 200000}, do_variation_200k_times({0, 0}, 0, fun(DynamicTarget) -> cfclient_evaluator:bool_variation(<<"My_boolean_flag">>, DynamicTarget, config()) end))},
-%%        {timeout, 30, ?_assertEqual({2, 2, 2}, do_variation_200k_times({0, 0}, 0, fun(DynamicTarget) -> cfclient_evaluator:string_variation(<<"My_string_flag">>, DynamicTarget, config()) end))}
-%%      },
-%%      {
-%%        "70/30",
-%%        setup,
-%%        fun
-%%          () ->
-%%            meck:expect(
-%%              cfclient_ets,
-%%              get,
-%%              fun
-%%                (_, <<"segments/target_group_1">>) ->
-%%                  cfclient_evaluator_test_data:target_group_for_percentage_rollout();
-%%
-%%                (_, <<"flags/My_boolean_flag">>) ->
-%%                  cfclient_evaluator_test_data:percentage_rollout_boolean(70, 30)
-%%              end
-%%            )
-%%        end,
-%%        {timeout, 30, ?_assertEqual({140098, 59902}, do_variation_200k_times({0, 0}, 0, fun(DynamicTarget) -> cfclient_evaluator:bool_variation(<<"My_boolean_flag">>, DynamicTarget, config()) end))},
-%%        {timeout, 30, ?_assertEqual({2, 2, 2}, do_variation_200k_times({0, 0}, 0, fun(DynamicTarget) -> cfclient_evaluator:string_variation(<<"My_string_flag">>, DynamicTarget, config()) end))}
-%%      }
     ]
   }.
 
 
-do_variation_200k_times({TrueCounter, FalseCounter}, 200000, _VariationFunction) -> {TrueCounter, FalseCounter};
+do_bool_variation_200k_times({TrueCounter, FalseCounter}, 200000) -> {TrueCounter, FalseCounter};
 
-do_variation_200k_times({TrueCounter, FalseCounter}, AccuIn, VariationFunction) ->
+do_bool_variation_200k_times({TrueCounter, FalseCounter}, AccuIn) ->
   Counter = AccuIn + 1,
   TargetIdentifierNumber = integer_to_binary(Counter),
   DynamicTarget =
@@ -1843,12 +1846,35 @@ do_variation_200k_times({TrueCounter, FalseCounter}, AccuIn, VariationFunction) 
       anonymous => <<"">>
     },
 %%  case cfclient_evaluator:bool_variation(<<"My_boolean_flag">>, DynamicTarget, config()) of
-  case VariationFunction(DynamicTarget) of
+  case cfclient_evaluator:bool_variation(<<"My_boolean_flag">>, DynamicTarget, config()) of
     {ok, _VariationIdentifier, true} ->
-      do_variation_200k_times({TrueCounter + 1, FalseCounter + 0}, Counter, VariationFunction);
+      do_bool_variation_200k_times({TrueCounter + 1, FalseCounter + 0}, Counter);
 
     {ok, _VariationIdentifier, false} ->
-      do_variation_200k_times({TrueCounter + 0, FalseCounter + 1}, Counter, VariationFunction)
+      do_bool_variation_200k_times({TrueCounter + 0, FalseCounter + 1}, Counter)
+  end.
+
+do_string_variation_200k_times({Variation1Counter, Variation2Counter, Variation3Counter}, 200000) -> {Variation1Counter, Variation2Counter, Variation3Counter};
+
+do_string_variation_200k_times({Variation1Counter, Variation2Counter, Variation3Counter}, AccuIn) ->
+  Counter = AccuIn + 1,
+  TargetIdentifierNumber = integer_to_binary(Counter),
+  DynamicTarget =
+    #{
+      identifier => <<"target", TargetIdentifierNumber/binary>>,
+      name => <<"targetname", TargetIdentifierNumber/binary>>,
+      anonymous => <<"">>
+    },
+%%  case cfclient_evaluator:bool_variation(<<"My_boolean_flag">>, DynamicTarget, config()) of
+  case cfclient_evaluator:string_variation(<<"My_string_flag">>, DynamicTarget, config()) of
+    {ok, _VariationIdentifier, <<"variation1">>} ->
+      do_string_variation_200k_times({Variation1Counter + 1, Variation2Counter + 0,  Variation3Counter + 0}, Counter);
+
+    {ok, _VariationIdentifier,  <<"variation2">>} ->
+      do_string_variation_200k_times({Variation1Counter + 0, Variation2Counter + 1,  Variation3Counter + 0}, Counter);
+
+    {ok, _VariationIdentifier,  <<"variation3">>} ->
+      do_string_variation_200k_times({Variation1Counter + 0, Variation2Counter + 0,  Variation3Counter + 1}, Counter)
   end.
 
 

--- a/test/cfclient_evaluator_tests.erl
+++ b/test/cfclient_evaluator_tests.erl
@@ -1991,7 +1991,6 @@ do_bool_variation_200k_times({TrueCounter, FalseCounter}, AccuIn) ->
       name => <<"targetname", TargetIdentifierNumber/binary>>,
       anonymous => <<"">>
     },
-  %%  case cfclient_evaluator:bool_variation(<<"My_boolean_flag">>, DynamicTarget, config()) of
   case cfclient_evaluator:bool_variation(<<"My_boolean_flag">>, DynamicTarget, config()) of
     {ok, _VariationIdentifier, true} ->
       do_bool_variation_200k_times({TrueCounter + 1, FalseCounter + 0}, Counter);
@@ -2013,7 +2012,6 @@ do_string_variation_200k_times({Variation1Counter, Variation2Counter, Variation3
       name => <<"targetname", TargetIdentifierNumber/binary>>,
       anonymous => <<"">>
     },
-  %%  case cfclient_evaluator:bool_variation(<<"My_boolean_flag">>, DynamicTarget, config()) of
   case cfclient_evaluator:string_variation(<<"My_string_flag">>, DynamicTarget, config()) of
     {ok, _VariationIdentifier, <<"variation1">>} ->
       do_string_variation_200k_times(
@@ -2040,8 +2038,6 @@ prerequisite_matches_flag1() -> cfclient_evaluator_test_data:prerequisite_matche
 prerequisite_matches_flag2() -> cfclient_evaluator_test_data:prerequisite_matches_flag_2().
 
 prerequisite_matches_flag3() -> cfclient_evaluator_test_data:prerequisite_matches_flag_3().
-
-%% Same flag data but with a target rule that doesn't include our sample Target1
 
 prerequisite_matches_flag4() ->
   #{


### PR DESCRIPTION
# What

Adds new percentage rollout tests for multivariate string flag, and additional scenarios for boolean flag. 