### PR TITLE
FFM-9804 Fix percentage rollout prefix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [3.0.0] - TBD - UPDATE WHEN RELEASED
+## ** Breaking for Erlang applications (not affecting Elixir applications) **
+
+- The percentage rollout hash algorithm was slightly different compared to other Feature Flags SDKs, which resulted
+- in a different bucket allocation for the same target. The overall distribution was the same, but this change ensures
+- that the same target will get the same allocation per SDK
+
 ## [2.0.1] - 2023-07-02
 ### Fixes
 - Some SDK dependencies were not getting included in releases created by `mix `
@@ -149,5 +156,4 @@ Evaluation Rules not yet complete:
   - Custom rules
 - Pre-requisites
 - Percentage Rollout
-  
   

--- a/src/cfclient.app.src
+++ b/src/cfclient.app.src
@@ -4,7 +4,7 @@
   [
     {description, "Harness Feature Flags Server SDK"},
     {pkg_name, "harness_ff_erlang_server_sdk"},
-    {vsn, "2.0.1"},
+    {vsn, "3.0.0"},
     {registered, []},
     {mod, {cfclient_app, []}},
     {applications, [kernel, stdlib, cfapi, base64url, murmur, jsx, mochiweb]},

--- a/src/cfclient_evaluator.erl
+++ b/src/cfclient_evaluator.erl
@@ -557,7 +557,7 @@ apply_percentage_rollout([], _, _, _) -> excluded.
 
 -spec should_rollout(binary(), binary(), integer()) -> boolean().
 should_rollout(BucketBy, TargetValue, Percentage) ->
-  Concatenated = <<TargetValue/binary, ":", BucketBy/binary>>,
+  Concatenated = <<BucketBy/binary, ":", TargetValue/binary>>,
   % Using a pure Elixir library for murmur3
   Hash = 'Elixir.Murmur':hash_x86_32(Concatenated),
   BucketID = (Hash rem 100) + 1,

--- a/src/cfclient_metrics_attributes.hrl
+++ b/src/cfclient_metrics_attributes.hrl
@@ -18,6 +18,6 @@
 %% Constants for Metrics Data Attribute Values
 
 -define(SDK_TYPE_ATTRIBUTE_VALUE, <<"server">>).
--define(SDK_VERSION_ATTRIBUTE_VALUE, <<"1.1.0">>).
+-define(SDK_VERSION_ATTRIBUTE_VALUE, <<"3.0.0">>).
 -define(SDK_LANGUAGE_ATTRIBUTE_VALUE, <<"erlang">>).
 -define(TARGET_GLOBAL_IDENTIFIER, <<"__global__cf_target">>).


### PR DESCRIPTION
# What 

Updates percentage rollout prefix to align with other SDKs. (also updates unit test values). 

Use `lists:fold` instead of custom recursion for unit test percentage rollout helper

# Why

The prefix is backwards in this SDK, and Ruby, compared to our other SDKs. 

# Testing

Unit tests