### PR TITLE
FFM-12000 Remove Flag/Group "version outdated" check

### DIFF
--- a/src/cfclient.app.src
+++ b/src/cfclient.app.src
@@ -4,7 +4,7 @@
   [
     {description, "Harness Feature Flags Server SDK"},
     {pkg_name, "harness_ff_erlang_server_sdk"},
-    {vsn, "3.0.0"},
+    {vsn, "3.0.1"},
     {registered, []},
     {mod, {cfclient_app, []}},
     {applications, [kernel, stdlib, cfapi, base64url, murmur, jsx, mochiweb]},

--- a/src/cfclient_cache.erl
+++ b/src/cfclient_cache.erl
@@ -47,41 +47,20 @@ get_value({Type, Identifier}, Config) ->
 
 % @doc Store flag or segment into cache with new value.
 -spec set_value({flag, binary()} | {segment, binary()}, flag() | segment()) ->
-  ok | {error, outdated}.
+  ok.
 set_value({Type, Identifier}, Value) ->
   Config = cfclient_config:get_config(),
   set_value({Type, Identifier}, Value, Config).
 
 
 -spec set_value({flag, binary()} | {segment, binary()}, flag() | segment(), config()) ->
-  ok | {error, outdated}.
+  ok.
 set_value({Type, Identifier}, Value, Config) ->
   #{cache_table := CacheTable} = Config,
-  case is_outdated({Type, Identifier}, Value, Config) of
-    true ->
-      % This should not happen
-      ?LOG_ERROR("Outdated type ~p, identifier ~p", [Type, Identifier]),
-      {error, outdated};
-
-    false ->
-      Key = format_key({Type, Identifier}),
-      true = ets:insert(CacheTable, {Key, Value}),
-      ?LOG_DEBUG("Cached type ~p, identifier ~p", [Type, Identifier]),
-      ok
-  end.
-
-
--spec is_outdated({flag, binary()} | {segment, binary()}, flag() | segment(), config()) ->
-  boolean().
-is_outdated(Key, NewValue, Config) ->
-  case get_value(Key, Config) of
-    {error, undefined} -> false;
-
-    {ok, OldValue} ->
-      #{version := OldVersion} = OldValue,
-      #{version := NewVersion} = NewValue,
-      OldVersion > NewVersion
-  end.
+  Key = format_key({Type, Identifier}),
+  true = ets:insert(CacheTable, {Key, Value}),
+  ?LOG_DEBUG("Cached type ~p, identifier ~p", [Type, Identifier]),
+  ok.
 
 
 % @doc Create binary key from flag or segment.
@@ -89,16 +68,16 @@ is_outdated(Key, NewValue, Config) ->
 format_key({flag, Identifier}) -> <<"flags/", Identifier/binary>>;
 format_key({segment, Identifier}) -> <<"segments/", Identifier/binary>>.
 
--spec cache_segment(segment()) -> ok | {error, outdated}.
+-spec cache_segment(segment()) -> ok.
 cache_segment(#{identifier := Id} = Value) -> set_value({segment, Id}, Value).
 
--spec cache_segment(segment(), config()) -> ok | {error, outdated}.
+-spec cache_segment(segment(), config()) -> ok.
 cache_segment(#{identifier := Id} = Value, Config) -> set_value({segment, Id}, Value, Config).
 
--spec cache_flag(flag()) -> ok | {error, outdated}.
+-spec cache_flag(flag()) -> ok.
 cache_flag(#{feature := Id} = Value) -> set_value({flag, Id}, Value).
 
--spec cache_flag(flag(), config()) -> ok | {error, outdated}.
+-spec cache_flag(flag(), config()) -> ok.
 cache_flag(#{feature := Id} = Value, Config) -> set_value({flag, Id}, Value, Config).
 
 -spec set_pid(pid()) -> ok.

--- a/src/cfclient_metrics_attributes.hrl
+++ b/src/cfclient_metrics_attributes.hrl
@@ -18,6 +18,6 @@
 %% Constants for Metrics Data Attribute Values
 
 -define(SDK_TYPE_ATTRIBUTE_VALUE, <<"server">>).
--define(SDK_VERSION_ATTRIBUTE_VALUE, <<"3.0.0">>).
+-define(SDK_VERSION_ATTRIBUTE_VALUE, <<"3.0.1">>).
 -define(SDK_LANGUAGE_ATTRIBUTE_VALUE, <<"erlang">>).
 -define(TARGET_GLOBAL_IDENTIFIER, <<"__global__cf_target">>).


### PR DESCRIPTION
# What
When caching a flag or group, we previously checked if the `version` was newer than that of the config stored.  This check is unnecessary, as we should allow SaaS/Proxy to be the source of truth.  This ensures that if a strange state where the stored version seems to be newer, we allow the SDK to store whatever SaaS/Proxy deems to be the latest. 

# Testing
TestGrid image - all evaluation scenarios pass
Manual smoke test with prod2 account 